### PR TITLE
LLM hardening: config + summarizer (WIP)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,10 +1,38 @@
+# src/config.py
+from __future__ import annotations
+
 import os
-from dotenv import load_dotenv
+from dataclasses import dataclass
+from functools import lru_cache
 
-load_dotenv()
 
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
+class ConfigError(RuntimeError):
+    """Raised when required configuration is missing or invalid."""
 
-if not OPENAI_API_KEY:
-    raise RuntimeError("OPENAI_API_KEY not set in .env")
+
+@dataclass(frozen=True)
+class Settings:
+    openai_api_key: str
+    openai_model: str
+
+
+def _get_env_var(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise ConfigError(
+            f"{name} is not set. "
+            "Set it in your environment (e.g. in .env or shell) before running this command."
+        )
+    return value
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """
+    Lazily load settings on first use so importing this module never fails.
+    """
+    return Settings(
+        openai_api_key=_get_env_var("OPENAI_API_KEY"),
+        # OPENAI_MODEL is optional; default to a reasonable model if not set.
+        openai_model=os.getenv("OPENAI_MODEL", "gpt-4.1-mini"),
+    )

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -1,0 +1,88 @@
+# src/llm_client.py
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from openai import OpenAI
+from .config import get_settings, ConfigError
+
+
+@dataclass
+class LLMCallError(RuntimeError):
+    message: str
+    last_response: Optional[str] = None
+
+
+def _get_model_name() -> str:
+    """
+    Resolve the model name, allowing an OPENAI_MODEL override.
+    """
+    return os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
+
+
+def call_llm_json(
+    *,
+    system_prompt: str,
+    user_prompt: str,
+    temperature: float = 0.2,
+    max_retries: int = 3,
+    timeout: float = 30.0,
+    model: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Call the LLM expecting a JSON object.
+
+    - Uses OpenAI chat.completions API.
+    - Retries on transient errors and JSON decode failures.
+    - Raises LLMCallError with the last raw response text on final failure.
+    """
+    last_raw: Optional[str] = None
+    model_name = model or _get_model_name()
+
+    for attempt in range(1, max_retries + 1):
+        try:
+            settings = get_settings()
+            client = OpenAI(api_key=settings.openai_api_key, timeout=timeout)
+
+            response = client.chat.completions.create(
+                model=model_name,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                response_format={"type": "json_object"},
+                temperature=temperature,
+            )
+
+            raw = response.choices[0].message.content
+            last_raw = raw
+            return json.loads(raw)
+
+        except json.JSONDecodeError:
+            # Model returned non-JSON; retry unless we’re out of attempts.
+            if attempt == max_retries:
+                raise LLMCallError(
+                    message="Failed to decode JSON from LLM after retries.",
+                    last_response=last_raw,
+                )
+            time.sleep(2**attempt)
+
+        except ConfigError:
+            # Config problems are not transient; re-raise immediately.
+            raise
+
+        except Exception as e:
+            if attempt == max_retries:
+                raise LLMCallError(
+                    message=f"LLM call failed after retries: {e}",
+                    last_response=last_raw,
+                )
+            time.sleep(2**attempt)
+
+    # Should never reach here
+    raise LLMCallError("Unexpected error in call_llm_json",
+                       last_response=last_raw)

--- a/src/report_builder.py
+++ b/src/report_builder.py
@@ -1,0 +1,104 @@
+# src/report_builder.py
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+@dataclass
+class PolicyReport:
+    policy_name: str
+    source_path: str
+    num_sections: int
+    num_unknown_sections: int
+    sections: List[Dict[str, Any]]
+
+
+def build_policy_report(summary: Dict[str, Any]) -> PolicyReport:
+    sections = summary.get("sections", []) or []
+    num_sections = len(sections)
+
+    def get_name(s: Dict[str, Any]) -> str:
+        return (s.get("name") or s.get("section_name") or "").strip()
+
+    num_unknown = sum(1 for s in sections if get_name(s).upper() == "UNKNOWN")
+
+    policy_name = (
+        summary.get("policy_name")
+        or Path(summary.get("policy_path", "")).name
+        or "Unknown policy"
+    )
+
+    return PolicyReport(
+        policy_name=policy_name,
+        source_path=summary.get("policy_path", ""),
+        num_sections=num_sections,
+        num_unknown_sections=num_unknown,
+        sections=sections,
+    )
+
+
+def render_markdown(report: PolicyReport) -> str:
+    lines: List[str] = []
+
+    lines.append(f"# Policy report: {report.policy_name}")
+    lines.append("")
+
+    if report.source_path:
+        lines.append(f"- Source file: `{report.source_path}`")
+    lines.append(f"- Total sections: {report.num_sections}")
+    lines.append(f"- Sections under UNKNOWN: {report.num_unknown_sections}")
+    lines.append("")
+
+    for section in report.sections:
+        name = (
+            section.get("name")
+            or section.get("section_name")
+            or "UNKNOWN"
+        )
+        summary = (
+            section.get("summary_overall")
+            or section.get("summary")
+            or ""
+        )
+
+        lines.append(f"## {name}")
+        lines.append("")
+        if summary:
+            lines.append(summary.strip())
+        else:
+            lines.append("_No summary for this section._")
+        lines.append("")
+
+        angles = section.get("dispute_angles_possible") or []
+        if angles:
+            lines.append("**Potential dispute angles:**")
+            lines.append("")
+            for a in angles:
+                lines.append(f"- {a}")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def build_and_save_markdown(summary_json_path: Path) -> Path:
+    """
+    Given the path to a PolicySummary JSON file, build and save a Markdown report
+    next to it (same name with `.report.md` suffix).
+    """
+    data = json.loads(summary_json_path.read_text(encoding="utf-8"))
+    report = build_policy_report(data)
+    markdown = render_markdown(report)
+
+    md_path = summary_json_path.with_suffix(".report.md")
+    md_path.write_text(markdown, encoding="utf-8")
+
+    if report.num_sections and report.num_unknown_sections / report.num_sections > 0.3:
+        print(
+            f"[WARN] {report.num_unknown_sections}/{report.num_sections} sections "
+            "are UNKNOWN. Section detection may need tuning."
+        )
+
+    return md_path

--- a/src/run_baseline_policy_summary.py
+++ b/src/run_baseline_policy_summary.py
@@ -7,6 +7,7 @@ from .pdf_loader import load_pdf_text
 from .sectioning import split_into_sections
 from .summarizer_frontier import summarize_section
 from .schemas import PolicySummary
+from .report_builder import build_and_save_markdown
 
 
 def summarize_policy(pdf_path: str, policy_id: str | None = None) -> PolicySummary:
@@ -60,6 +61,10 @@ def main():
         json.dump(summary.to_dict(), f, indent=2, ensure_ascii=False)
 
     print(f"[bold green]Saved summary to:[/bold green] {out_path}")
+
+    # NEW: build Markdown report next to the JSON
+    md_path = build_and_save_markdown(out_path)
+    print(f"[bold green]Saved Markdown report to:[/bold green] {md_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Phase 1 of LLM hardening:

- Refactor `src/config.py` to lazy-load OpenAI settings via `get_settings()`
  instead of failing at import time.
- Update `summarizer_frontier.py` to use the new config helper.

Next steps (still WIP on this branch):
- Add `llm_client.py` with retries + JSON parsing.
- Wire summarizer to use `llm_client`.
- Add tests + docs later.