### PR TITLE
Feature/denial report v0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 itprodirect
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,257 @@
+# Policy Dispute AI Assistant
+
+AI assistant for turning **homeowners insurance policies (HO3)** and **claim denial letters** into **dispute‑focused reports**.
+
+- Designed for **public adjusters, coverage counsel, and their teams**
+- Built to **surface leverage points and blind spots**, not to replace human judgment
+- **Not legal advice** and not a coverage determination
+
+---
+
+## What this tool does
+
+### 1. Policy‑only summary (baseline)
+
+Feed it one or more HO3 policy PDFs and it will:
+
+- Split each policy into logical sections (Definitions, Coverages, Exclusions, Conditions, endorsements, etc.)
+- Summarize each section in plain English
+- Extract:
+
+  - Key coverages
+  - Key exclusions / limitations
+  - Notable conditions / duties
+  - Possible dispute angles to explore
+
+- Tag sections as **substantive** vs **meta / boilerplate** (regulator pages, ISO copyright, sample notices, etc.)
+- Emit a **claim‑facing Markdown report** per policy
+
+Outputs live in `data/processed/<POLICY_ID>.report.md`.
+
+### 2. Policy + denial A–G dispute report (v0)
+
+Given:
+
+- A **policy summary JSON** (from the baseline pipeline), and
+- A **denial letter in plain text**
+
+the tool builds a **structured A–G dispute report**:
+
+**A.** Plain‑English overview of the dispute
+**B.** Coverage highlights that may support the insured
+**C.** Key exclusions / limitations that may hurt the insured
+**D.** Denial reasons (as stated / implied by the insurer)
+**E.** Possible dispute angles to explore (not legal advice)
+**F.** Missing information / suggested next steps
+**G.** Confidence + clauses to double‑check
+
+This is the view you’d actually use in a claim review, mediation prep, or internal strategy meeting.
+
+When you run the examples below, dispute reports are written as:
+
+- JSON: `data/processed/<POLICY_ID>__<DENIAL_ID>.dispute.json`
+- Markdown: `data/processed/<POLICY_ID>__<DENIAL_ID>.dispute.md`
+
+---
+
+## Who this is for
+
+- **Public adjusters** who want a first pass on complex policies and denials
+- **Coverage and property‑damage attorneys** who want faster "issue spotting"
+- **Technical folks** building internal tools for claims/legal teams
+- Anyone curious about **how AI can assist** in coverage disputes without giving legal advice
+
+If you’re non‑technical, you can still skim the example reports to see the kind of structure this tool produces.
+
+---
+
+## Project structure
+
+```text
+data/
+  raw_policies/      # Input PDFs (HO3 sample forms, carrier forms)
+  raw_denials/       # Input denial letters as .txt
+  processed/         # JSON + Markdown outputs
+
+notebooks/           # Exploration / development notebooks
+
+src/
+  config.py          # Environment + model settings
+  llm_client.py      # OpenAI client + JSON helper
+  pdf_loader.py      # PDF -> text
+  sectioning.py      # Policy section splitter + role tagging
+  summarizer_frontier.py
+                     # Section summarizer + denial-aware report builder
+  run_baseline_policy_summary.py
+                     # CLI: policies -> section summaries (JSON)
+  report_builder.py  # CLI helpers + Markdown renderers
+  run_denial_summary.py
+                     # CLI: policy JSON + denial.txt -> A–G dispute report
+```
+
+---
+
+## Getting started
+
+### 1. Clone and create a virtualenv
+
+```bash
+git clone https://github.com/itprodirect/policy-dispute-ai-assistant.git
+cd policy-dispute-ai-assistant
+
+python -m venv .venv
+# Windows
+source .venv/Scripts/activate
+# macOS / Linux
+# source .venv/bin/activate
+
+pip install -r requirements.txt
+```
+
+### 2. Configure your OpenAI API key
+
+Create a `.env` file in the project root (you can copy from `.env.example` if it exists):
+
+```bash
+OPENAI_API_KEY=sk-...
+# optional override, otherwise defaults are set in config.py
+OPENAI_MODEL=gpt-4.1-mini
+```
+
+The code uses `src/config.py` and `src/llm_client.py` to read these values.
+
+### 3. Add some sample policies
+
+Drop HO3 policy PDFs into:
+
+```text
+data/raw_policies/
+```
+
+The repo includes anonymized samples, for example:
+
+- `HO3_TRUE_FL_2021.pdf`
+- `HO3_USAA_TX_OPIC_2008.pdf`
+- ISO and carrier variants
+
+### 4. Run the baseline policy summarizer
+
+This builds normalized JSON summaries and claim‑facing Markdown reports.
+
+```bash
+# Summarize all PDFs in data/raw_policies/
+python -m src.run_baseline_policy_summary data/raw_policies
+```
+
+Outputs:
+
+- JSON: `data/processed/<POLICY_ID>.json`
+- Markdown: `data/processed/<POLICY_ID>.report.md`
+
+Open one of the `.report.md` files in VS Code or GitHub to see the structure.
+
+### 5. Add a denial letter
+
+For now, v0 expects a **plain‑text** denial letter.
+
+Put a `.txt` file in:
+
+```text
+data/raw_denials/
+```
+
+Example (included or easy to recreate):
+
+- `data/raw_denials/HO3_TRUE_FL_2021_denial.txt`
+
+This is a realistic water‑damage denial (late notice, long‑term leakage, deductible issues, etc.).
+
+### 6. Build an A–G dispute report
+
+Use the denial‑aware CLI:
+
+```bash
+python -m src.run_denial_summary \
+  data/processed/HO3_TRUE_FL_2021.json \
+  data/raw_denials/HO3_TRUE_FL_2021_denial.txt
+```
+
+This writes:
+
+- JSON: `data/processed/HO3_TRUE_FL_2021__HO3_TRUE_FL_2021_denial.dispute.json`
+- Markdown: `data/processed/HO3_TRUE_FL_2021__HO3_TRUE_FL_2021_denial.dispute.md`
+
+Open the `.md` in your editor or on GitHub to see the full A–G analysis.
+
+You can reuse the same denial against different policies to stress‑test behavior:
+
+```bash
+python -m src.run_denial_summary \
+  data/processed/HO3_USAA_TX_OPIC_2008.json \
+  data/raw_denials/HO3_TRUE_FL_2021_denial.txt
+```
+
+---
+
+## Command reference
+
+### Baseline policy summary
+
+```bash
+python -m src.run_baseline_policy_summary <path-or-directory>
+```
+
+Example:
+
+```bash
+python -m src.run_baseline_policy_summary data/raw_policies
+```
+
+### Policy + denial A–G dispute report
+
+```bash
+python -m src.run_denial_summary <policy_summary.json> <denial_letter.txt>
+```
+
+Example:
+
+```bash
+python -m src.run_denial_summary \
+  data/processed/HO3_TRUE_FL_2021.json \
+  data/raw_denials/HO3_TRUE_FL_2021_denial.txt
+```
+
+---
+
+## Safety, limitations, and disclaimers
+
+This project is **experimental** and intended for **education and workflow support only**.
+
+- It **does not provide legal advice**.
+- It **does not make coverage determinations**.
+- It can misread OCR’d text, mis‑interpret policy language, or miss important nuances.
+- Any outputs **must be reviewed by a licensed professional** before being relied on.
+
+If you use this in real‑world work:
+
+- Treat it as a **research assistant** or “issue spotter,” not a decision‑maker.
+- Always cross‑check cited clauses against the actual policy and endorsements.
+- Be mindful of confidentiality and PII if you process real claims.
+
+---
+
+## Roadmap (high‑level)
+
+Some directions under consideration:
+
+- **UI demo** (Streamlit or similar) so non‑technical users can drag‑and‑drop policies and denials.
+- **Voice mode v1**: push‑to‑talk interface on top of the same A–G analysis.
+- Better **section taxonomy** (base form vs endorsements vs meta) in the reports.
+- Model/cost tuning and caching for large batches of policies.
+- Integration with richer document stores and RAG pipelines for large claim files.
+
+---
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/data/processed/HO3_TRUE_FL_2021__HO3_TRUE_FL_2021_denial.dispute.md
+++ b/data/processed/HO3_TRUE_FL_2021__HO3_TRUE_FL_2021_denial.dispute.md
@@ -1,0 +1,68 @@
+# Policy dispute summary
+
+- Policy: `HO3_TRUE_FL_2021`
+- Denial: `HO3_TRUE_FL_2021_denial`
+
+> **Framing:** This is an AI-generated analysis of policy language and a denial letter.
+> It is *not* legal advice and does not create coverage, rights, or an attorney–client relationship.
+
+## A. Plain-English overview of the dispute
+
+The insureds reported water damage to their kitchen and living room, but the insurer denied the claim primarily due to late notice, damage caused by long-term leakage and wear and tear, pre-existing damage, failure to protect the property from further damage, and the loss amount being below the deductible. The insurer relies on policy conditions requiring prompt notice and duties after loss, as well as exclusions for gradual damage and deterioration.
+
+## B. Coverage highlights that may support the insured
+
+- Coverage for sudden and accidental direct physical loss to the dwelling and attached structures. (SECTION: SECTION I - PERILS INSURED AGAINST; SECTION I - PROPERTY COVERAGES)
+- Limited additional coverage for damage related to fungi, wet or dry rot, or bacteria, subject to specific conditions and limits. (SECTION I - PROPERTY COVERAGES)
+
+## C. Key exclusions / limitations that may hurt the insured
+
+- Exclusion of loss caused by wear and tear, deterioration, and continuous or repeated seepage or leakage of water over time. (SECTION: EXCLUSIONS; SECTION I - PROPERTY COVERAGES)
+- Requirement for prompt notice of loss and cooperation; late notice that prejudices the insurer can lead to denial. (SECTION: CONDITIONS; SECTION: COVERAGE U - NDER THIS POLICY TO AN “ASSIGNEE” IF THE)
+- Deductible applies to covered losses; losses below deductible amount are not payable. (SECTION I - PROPERTY COVERAGES; SECTION: CONDITIONS)
+- Obligation to protect property from further damage after loss; failure to do so can limit or void coverage for additional damage. (SECTION I - PROPERTY COVERAGES; SECTION: CONDITIONS)
+
+## D. Denial reasons (as stated or implied by the insurer)
+
+- Late notice of the loss prevented timely inspection and investigation, prejudicing the insurer. (SECTION: CONDITIONS; SECTION: DUTIES AFTER LOSS)
+- Damage resulted from long-term leakage and wear and tear, which are excluded per policy terms. (SECTION: EXCLUSIONS; SECTION I - PROPERTY COVERAGES)
+- Some damage pre-existed the reported loss date, and the insured failed to take reasonable steps to protect the property from further damage. (SECTION I - PROPERTY COVERAGES; SECTION: CONDITIONS)
+- The amount of covered damage after depreciation and exclusions is below the applicable deductible, so no payment is owed. (SECTION I - PROPERTY COVERAGES; SECTION: CONDITIONS)
+
+## E. Possible dispute angles to explore (not legal advice)
+
+- Whether the insured’s notice delay was unreasonable and whether the insurer was truly prejudiced by the late notice.  
+  _Citations: SECTION: CONDITIONS, SECTION: DUTIES AFTER LOSS_
+- Whether the damage was caused by a sudden and accidental event or by excluded long-term leakage and wear and tear.  
+  _Citations: SECTION I - PROPERTY COVERAGES, SECTION: EXCLUSIONS_
+- Extent and timing of pre-existing damage versus damage caused by the reported loss date.  
+  _Citations: SECTION I - PROPERTY COVERAGES_
+- Whether the insured took reasonable and timely steps to protect the property from further damage after the loss.  
+  _Citations: SECTION I - PROPERTY COVERAGES, SECTION: CONDITIONS_
+- Calculation and application of depreciation and deductible to determine if any covered loss amount remains payable.  
+  _Citations: SECTION I - PROPERTY COVERAGES, SECTION: CONDITIONS_
+- Whether any fungi, wet or dry rot, or bacterial damage is covered under the limited additional coverage and if limits apply.  
+  _Citations: SECTION I - PROPERTY COVERAGES_
+- Potential ambiguity in definitions of 'wear and tear' and 'continuous leakage' and how these apply to the specific damage observed.  
+  _Citations: SECTION: EXCLUSIONS, SECTION I - PROPERTY COVERAGES_
+
+## F. Missing information / suggested next steps
+
+- Exact date and manner in which the insured first noticed the damage.
+- Any documentation or communication showing when the insured reported the loss to the insurer.
+- Detailed plumber’s report and inspection findings supporting long-term leakage conclusion.
+- Photos or reports documenting the condition of the property immediately before and after the loss date.
+- Evidence of any emergency or mitigation measures taken by the insured after the loss.
+- Itemized estimate or repair costs showing depreciation and deductible application.
+- Policy declarations page showing deductible amounts and coverage limits.
+
+## G. Confidence and clauses to verify
+
+- **Confidence score (0–1):** 0.90
+- **Notes:** The denial letter clearly cites policy conditions and exclusions that align with the policy summaries provided. The main issues of late notice, wear and tear exclusion, pre-existing damage, and deductible application are well supported. However, some ambiguity remains around the exact timing and nature of damage and mitigation efforts, which could affect coverage analysis.
+- **Clauses / sections to double-check:**
+  - SECTION: CONDITIONS
+  - SECTION I - PROPERTY COVERAGES
+  - SECTION: EXCLUSIONS
+  - SECTION: DUTIES AFTER LOSS
+  - SECTION: COVERAGE U - NDER THIS POLICY TO AN “ASSIGNEE” IF THE

--- a/data/processed/HO3_USAA_TX_OPIC_2008__HO3_TRUE_FL_2021_denial.dispute.md
+++ b/data/processed/HO3_USAA_TX_OPIC_2008__HO3_TRUE_FL_2021_denial.dispute.md
@@ -1,0 +1,71 @@
+# Policy dispute summary
+
+- Policy: `HO3_USAA_TX_OPIC_2008`
+- Denial: `HO3_TRUE_FL_2021_denial`
+
+> **Framing:** This is an AI-generated analysis of policy language and a denial letter.
+> It is *not* legal advice and does not create coverage, rights, or an attorney–client relationship.
+
+## A. Plain-English overview of the dispute
+
+The insureds reported water damage to their kitchen and living room nearly a month after the loss occurred. The insurer denied the claim citing late notice, damage caused by long-term leakage and wear and tear, pre-existing damage, failure to protect the property from further damage, and that the covered loss amount is below the deductible. The dispute centers on whether the damage qualifies as a covered sudden and accidental loss and whether policy conditions regarding notice and property protection were met.
+
+## B. Coverage highlights that may support the insured
+
+- Coverage for sudden and accidental direct physical damage to tangible property under Coverage A - Dwelling Protection. (COVERAGE A - DWELLING PROTECTION EXCEPT AS SPECIFICALLY PROVIDED IN SECTION I -)
+- Coverage for reasonable and necessary repairs to protect property from further damage after a covered loss under Additional Coverages. (ADDITIONAL COVERAGES)
+- Coverage for water damage caused by sudden and accidental discharge of water, subject to exclusions and conditions. (PROTECTION AND PERSONAL PROPERTY; DWELLING PROTECTION AND OTHER)
+
+## C. Key exclusions / limitations that may hurt the insured
+
+- Exclusion of loss caused by wear and tear, deterioration, and continuous or repeated seepage or leakage of water over time. (LOSSES WE DO NOT COVER UNDER DWELLING PROTECTION AND OTHER STRUCTURES)
+- Requirement for prompt notice of loss and cooperation with insurer’s investigation; late notice may result in denial. (COVERAGE F - OR YOUR LOSS IF YOU FAIL TO; CONDITIONS)
+- Obligation of insured to protect property from further damage and make reasonable repairs after loss. (COVERAGE F - OR YOUR LOSS IF YOU FAIL TO; ADDITIONAL COVERAGES)
+- Application of deductible to losses; insurer pays only amounts exceeding deductible. (DEDUCTIBLE)
+
+## D. Denial reasons (as stated or implied by the insurer)
+
+- Late notice of the loss prevented timely inspection and investigation, prejudicing the insurer. (COVERAGE F - OR YOUR LOSS IF YOU FAIL TO (Duties After Loss and Conditions sections))
+- Damage resulted from long-term leakage and wear and tear, which are excluded under the policy. (LOSSES WE DO NOT COVER UNDER DWELLING PROTECTION AND OTHER STRUCTURES)
+- Some damage pre-existed the reported loss and the insured failed to take reasonable steps to protect the property from further damage. (COVERAGE F - OR YOUR LOSS IF YOU FAIL TO; CONDITIONS)
+- The estimated covered damage after depreciation and exclusions is below the policy deductible, so no payment is owed. (DEDUCTIBLE)
+
+## E. Possible dispute angles to explore (not legal advice)
+
+- Whether the insured provided notice of loss within a reasonable or required timeframe and if late notice prejudiced the insurer.  
+  _Citations: COVERAGE F - OR YOUR LOSS IF YOU FAIL TO, CONDITIONS_
+- Whether the water damage was caused by a sudden and accidental event or by long-term leakage and wear and tear excluded by the policy.  
+  _Citations: LOSSES WE DO NOT COVER UNDER DWELLING PROTECTION AND OTHER STRUCTURES, PROTECTION AND PERSONAL PROPERTY_
+- Whether any damage pre-existed the loss date and how pre-existing damage affects coverage.  
+  _Citations: COVERAGE F - OR YOUR LOSS IF YOU FAIL TO, CONDITIONS_
+- Whether the insured took reasonable and necessary steps to protect the property from further damage after the loss.  
+  _Citations: ADDITIONAL COVERAGES, COVERAGE F - OR YOUR LOSS IF YOU FAIL TO_
+- Whether the estimated covered damage exceeds the deductible after depreciation and exclusions.  
+  _Citations: DEDUCTIBLE_
+- Clarification of what constitutes 'wear and tear' and 'long-term leakage' versus sudden accidental discharge of water.  
+  _Citations: DEFINITIONS, LOSSES WE DO NOT COVER UNDER DWELLING PROTECTION AND OTHER STRUCTURES_
+- Whether microbial damage or mold resulting from water intrusion is covered if caused by a covered peril.  
+  _Citations: SECTION I - LOSSES WE DO NOT COVER 1.I. MICROBIAL ORGANISMS , INCLUDING BUT NOT_
+
+## F. Missing information / suggested next steps
+
+- Exact date and manner of initial notice to insurer by the insured.
+- Detailed timeline and documentation of any emergency mitigation or repairs performed after the loss.
+- Complete plumber’s report and inspection findings with photos and dates.
+- Home inspection report and contractor estimates showing pre-existing damage.
+- Policy declarations page showing deductible amounts and coverage limits.
+- Any correspondence or communications between insured and insurer regarding the claim.
+- Detailed inventory or proof of damaged property and repair estimates.
+- Policy endorsements or amendments that might affect water damage or notice requirements.
+
+## G. Confidence and clauses to verify
+
+- **Confidence score (0–1):** 0.90
+- **Notes:** The denial letter clearly cites policy conditions and exclusions that align with the summarized policy sections. The main issues of late notice, wear and tear exclusion, pre-existing damage, and deductible application are well supported by the policy summaries. However, some ambiguity remains regarding the exact timing and nature of the loss and insured actions, which affects certainty.
+- **Clauses / sections to double-check:**
+  - COVERAGE F - OR YOUR LOSS IF YOU FAIL TO
+  - LOSSES WE DO NOT COVER UNDER DWELLING PROTECTION AND OTHER STRUCTURES
+  - DEDUCTIBLE
+  - ADDITIONAL COVERAGES
+  - PROTECTION AND PERSONAL PROPERTY
+  - SECTION I - LOSSES WE DO NOT COVER 1.I. MICROBIAL ORGANISMS , INCLUDING BUT NOT

--- a/src/run_denial_summary.py
+++ b/src/run_denial_summary.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from rich import print
+
+from .summarizer_frontier import build_denial_aware_report
+from .schemas import DisputeReport
+from .report_builder import render_dispute_markdown
+
+DATA_PROCESSED_DIR = Path("data/processed")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build a dispute-focused A–G report from a policy summary JSON "
+            "and a denial letter text file."
+        )
+    )
+    parser.add_argument(
+        "policy_summary",
+        help="Path to policy summary JSON (output of run_baseline_policy_summary.py).",
+    )
+    parser.add_argument(
+        "denial_text",
+        help="Path to denial letter .txt file (v0 uses plain text, not PDF).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    policy_path = Path(args.policy_summary)
+    denial_path = Path(args.denial_text)
+
+    if not policy_path.is_file():
+        print(f"[red]Policy summary JSON not found:[/red] {policy_path}")
+        return
+
+    if not denial_path.is_file():
+        print(f"[red]Denial text file not found:[/red] {denial_path}")
+        return
+
+    print(f"[bold]Loading policy summary:[/bold] {policy_path}")
+    policy_payload = json.loads(policy_path.read_text(encoding="utf-8"))
+
+    print(f"[bold]Loading denial letter text:[/bold] {denial_path}")
+    denial_text = denial_path.read_text(encoding="utf-8", errors="ignore")
+
+    print("[bold]Calling LLM to build denial-aware dispute report...[/bold]")
+    dispute_report: DisputeReport = build_denial_aware_report(
+        policy_payload, denial_text
+    )
+
+    # Attach simple metadata
+    policy_id = policy_payload.get("policy_id") or policy_path.stem
+    denial_id = denial_path.stem
+    dispute_report.policy_id = policy_id
+    dispute_report.denial_id = denial_id
+
+    DATA_PROCESSED_DIR.mkdir(parents=True, exist_ok=True)
+    base_name = f"{policy_id}__{denial_id}.dispute"
+
+    json_out = DATA_PROCESSED_DIR / f"{base_name}.json"
+    md_out = DATA_PROCESSED_DIR / f"{base_name}.md"
+
+    json_out.write_text(
+        json.dumps(dispute_report.to_dict(), indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    print(f"[green]Wrote dispute JSON:[/green] {json_out}")
+
+    md_text = render_dispute_markdown(dispute_report)
+    md_out.write_text(md_text, encoding="utf-8")
+    print(f"[green]Wrote dispute Markdown:[/green] {md_out}")
+
+    print("[bold]Done.[/bold]")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -1,5 +1,10 @@
-from dataclasses import dataclass, asdict
-from typing import List, Dict, Any
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict, field
+from typing import List, Dict, Any, Optional
+
+
+# --- Existing section-level summaries ----------------------------------------
 
 
 @dataclass
@@ -19,6 +24,62 @@ class SectionSummary:
 class PolicySummary:
     policy_id: str
     sections: List[SectionSummary]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+# --- New dispute-level summaries (policy + denial) ---------------------------
+
+
+@dataclass
+class Point:
+    """
+    Simple text point with an optional citation label
+    (e.g. section name, page reference).
+    """
+    text: str
+    citation: Optional[str] = None
+
+
+@dataclass
+class Angle:
+    """
+    High-level dispute angle with optional list of citations.
+    """
+    text: str
+    citations: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ConfidenceBlock:
+    """
+    Lightweight confidence / verification metadata.
+    """
+    score: Optional[float] = None  # 0–1, optional
+    notes: str = ""
+    verify_clauses: List[str] = field(default_factory=list)
+
+
+@dataclass
+class DisputeReport:
+    """
+    Canonical A–G style dispute report for a policy + denial pair.
+
+    This is what UI, CLI, and (later) voice mode should consume.
+    """
+    # Optional metadata about the case
+    policy_id: Optional[str] = None
+    denial_id: Optional[str] = None
+
+    # A–G sections
+    plain_summary: str = ""  # A
+    coverage_highlights: List[Point] = field(default_factory=list)        # B
+    exclusions_limitations: List[Point] = field(default_factory=list)     # C
+    denial_reasons: List[Point] = field(default_factory=list)             # D
+    dispute_angles: List[Angle] = field(default_factory=list)             # E
+    missing_info: List[str] = field(default_factory=list)                 # F
+    confidence: ConfidenceBlock = field(default_factory=ConfidenceBlock)  # G
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)

--- a/src/summarizer_frontier.py
+++ b/src/summarizer_frontier.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
-from .llm_client import call_llm_json, LLMCallError
-from .schemas import SectionSummary
+from typing import Any, Dict, List
 
+from .llm_client import call_llm_json, LLMCallError
+from .schemas import (
+    SectionSummary,
+    DisputeReport,
+    Point,
+    Angle,
+    ConfidenceBlock,
+)
+
+
+# --- Existing section-level summarization ------------------------------------
 
 SYSTEM_PROMPT = """You are an assistant that summarizes property insurance policy sections and denial letters for attorneys and public adjusters.
 - Use plain English.
@@ -62,4 +72,219 @@ def summarize_section(section_name: str, section_text: str) -> SectionSummary:
         key_exclusions=data.get("key_exclusions", []) or [],
         conditions_notable=data.get("conditions_notable", []) or [],
         dispute_angles_possible=data.get("dispute_angles_possible", []) or [],
+    )
+
+
+# --- New denial-aware dispute report builder ---------------------------------
+
+DENIAL_SYSTEM_PROMPT = """You are an assistant that analyzes property insurance coverage disputes.
+You work with:
+- A pre-summarized policy (by section).
+- A claim denial letter.
+
+Rules:
+- Use plain English.
+- Do NOT give legal advice or coverage determinations.
+- Do NOT invent terms or rights not clearly supported by the text.
+- Be conservative and factual.
+"""
+
+
+def _build_policy_overview_block(policy_summary_payload: Dict[str, Any]) -> str:
+    """
+    Compress the policy summary into a compact, LLM-friendly view:
+    section name + overall summary + dispute angles (if any).
+    """
+    sections = policy_summary_payload.get("sections", []) or []
+    lines: List[str] = []
+
+    for s in sections:
+        name = (s.get("section_name") or "UNKNOWN").strip()
+        summary = (s.get("summary_overall") or "").strip()
+        angles = s.get("dispute_angles_possible") or []
+
+        if not summary and not angles:
+            continue
+
+        lines.append(f"SECTION: {name}")
+        if summary:
+            lines.append(f"  SUMMARY: {summary}")
+        if angles:
+            joined = "; ".join(str(a) for a in angles if str(a).strip())
+            if joined:
+                lines.append(f"  DISPUTE_ANGLES: {joined}")
+        lines.append("")  # blank line between sections
+
+    if not lines:
+        return "[No usable policy summaries available.]"
+
+    return "\n".join(lines)
+
+
+def _build_denial_user_prompt(
+    policy_summary_payload: Dict[str, Any],
+    denial_text: str,
+) -> str:
+    policy_block = _build_policy_overview_block(policy_summary_payload)
+
+    return f"""
+You are analyzing a property insurance coverage dispute involving:
+
+1) A homeowners policy that has already been summarized by section.
+2) A claim denial letter.
+
+POLICY SUMMARY (BY SECTION)
+---------------------------
+{policy_block}
+
+DENIAL LETTER
+-------------
+\"\"\"{denial_text}\"\"\"
+
+
+Task:
+
+1. Provide a short 2–4 sentence plain-English overview of the dispute.
+2. Extract 3–7 key denial reasons from the denial letter.
+   - Each reason should be concise and refer to the insurer's stated position.
+3. For each denial reason, reference the most relevant policy section(s) by section name
+   (e.g. "EXCLUSIONS", "COVERAGE A - DWELLING", "DEFINITIONS").
+4. Identify the most important coverage grants that could potentially support the insured.
+5. Identify the most important exclusions or limitations that may hurt the insured.
+6. Suggest 3–8 high-level dispute angles a public adjuster or attorney might want to explore.
+   - These are NOT legal conclusions. They are simply "areas to check" or questions to ask.
+7. List any missing information, documents, or facts that would be useful to clarify the dispute.
+8. Provide a simple confidence block:
+   - A numeric score between 0 and 1 (0 = very low confidence, 1 = very high confidence).
+   - A short note explaining why.
+   - A list of specific clauses/sections that should always be double-checked.
+
+Return STRICT JSON with this structure:
+
+{{
+  "plain_summary": "string",
+  "coverage_highlights": [{{"text": "string", "citation": "string"}}],
+  "exclusions_limitations": [{{"text": "string", "citation": "string"}}],
+  "denial_reasons": [{{"text": "string", "citation": "string"}}],
+  "dispute_angles": [{{"text": "string", "citations": ["string", ...]}}],
+  "missing_info": ["string", ...],
+  "confidence": {{
+      "score": 0.0,
+      "notes": "string",
+      "verify_clauses": ["string", ...]
+  }}
+}}
+""".strip()
+
+
+def _parse_points(raw_points: Any) -> List[Point]:
+    points: List[Point] = []
+    if not isinstance(raw_points, list):
+        return points
+
+    for item in raw_points:
+        if isinstance(item, str):
+            text = item.strip()
+            if text:
+                points.append(Point(text=text))
+        elif isinstance(item, dict):
+            text = str(item.get("text", "")).strip()
+            if not text:
+                continue
+            citation = item.get("citation")
+            if citation is not None:
+                citation = str(citation).strip() or None
+            points.append(Point(text=text, citation=citation))
+    return points
+
+
+def _parse_angles(raw_angles: Any) -> List[Angle]:
+    angles: List[Angle] = []
+    if not isinstance(raw_angles, list):
+        return angles
+
+    for item in raw_angles:
+        if isinstance(item, str):
+            text = item.strip()
+            if text:
+                angles.append(Angle(text=text))
+        elif isinstance(item, dict):
+            text = str(item.get("text", "")).strip()
+            if not text:
+                continue
+            raw_cits = item.get("citations") or []
+            citations: List[str] = []
+            if isinstance(raw_cits, list):
+                for c in raw_cits:
+                    s = str(c).strip()
+                    if s:
+                        citations.append(s)
+            angles.append(Angle(text=text, citations=citations))
+    return angles
+
+
+def _parse_confidence(raw_conf: Any) -> ConfidenceBlock:
+    if not isinstance(raw_conf, dict):
+        return ConfidenceBlock()
+
+    score_raw = raw_conf.get("score")
+    score: float | None
+    if isinstance(score_raw, (int, float)):
+        score = float(score_raw)
+    else:
+        score = None
+
+    notes = str(raw_conf.get("notes", "") or "")
+    raw_verify = raw_conf.get("verify_clauses") or []
+    verify_clauses: List[str] = []
+    if isinstance(raw_verify, list):
+        for v in raw_verify:
+            s = str(v).strip()
+            if s:
+                verify_clauses.append(s)
+
+    return ConfidenceBlock(score=score, notes=notes, verify_clauses=verify_clauses)
+
+
+def build_denial_aware_report(
+    policy_summary_payload: Dict[str, Any],
+    denial_text: str,
+) -> DisputeReport:
+    """
+    High-level dispute report builder: policy summary JSON + denial text -> DisputeReport.
+    """
+    user_prompt = _build_denial_user_prompt(
+        policy_summary_payload, denial_text)
+
+    data = call_llm_json(
+        system_prompt=DENIAL_SYSTEM_PROMPT,
+        user_prompt=user_prompt,
+        temperature=0.2,
+        max_retries=3,
+        timeout=60.0,
+    )
+
+    plain_summary = str(data.get("plain_summary", "") or "").strip()
+    coverage_highlights = _parse_points(data.get("coverage_highlights"))
+    exclusions_limitations = _parse_points(data.get("exclusions_limitations"))
+    denial_reasons = _parse_points(data.get("denial_reasons"))
+    dispute_angles = _parse_angles(data.get("dispute_angles"))
+    raw_missing = data.get("missing_info") or []
+    missing_info: List[str] = []
+    if isinstance(raw_missing, list):
+        for m in raw_missing:
+            s = str(m).strip()
+            if s:
+                missing_info.append(s)
+
+    confidence = _parse_confidence(data.get("confidence"))
+
+    return DisputeReport(
+        plain_summary=plain_summary,
+        coverage_highlights=coverage_highlights,
+        exclusions_limitations=exclusions_limitations,
+        denial_reasons=denial_reasons,
+        dispute_angles=dispute_angles,
+        missing_info=missing_info,
+        confidence=confidence,
     )


### PR DESCRIPTION
This PR adds the first denial-aware dispute report flow.

- Add `DisputeReport` schema for A–G style policy + denial analysis
- Add denial-aware report builder to `summarizer_frontier.py`
- Add `run_denial_summary.py` CLI (policy JSON + denial .txt -> dispute report)
- Add A–G Markdown renderer in `report_builder.py`
- Add sample dispute reports for TRUE FL 2021 and USAA TX (Markdown)
- Add top-level README with usage, safety notes, and roadmap
- Add MIT LICENSE