### PR TITLE
Feature/wandb run telemetry

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(python -m py_compile:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,9 @@
 {
   "permissions": {
     "allow": [
-      "Bash(python -m py_compile:*)"
+      "Bash(python -m py_compile:*)",
+      "Bash(ls:*)",
+      "Bash(python -m scripts.model_compare:*)"
     ]
   }
 }

--- a/scripts/model_compare.py
+++ b/scripts/model_compare.py
@@ -176,7 +176,11 @@ def run_model_comparison() -> None:
             print(f"[FAIL] {result['model']:20s} | Error: {result['error']}")
 
     if settings.wandb_enabled:
-        print(f"\n[W&B] View runs in W&B: https://wandb.ai/{settings.wandb_entity}/{settings.wandb_project}")
+        if settings.wandb_entity:
+            project_url = f"https://wandb.ai/{settings.wandb_entity}/{settings.wandb_project}"
+        else:
+            project_url = f"https://wandb.ai/{settings.wandb_project}"
+        print(f"\n[W&B] View runs in W&B: {project_url}")
         print(f"   Filter by tag: mode=model_compare")
     else:
         print(f"\n[TIP] Enable W&B logging: WANDB_ENABLED=true in .env")

--- a/scripts/model_compare.py
+++ b/scripts/model_compare.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Model comparison script for W&B telemetry validation.
+
+Runs the same policy + denial fixture through multiple models and
+creates separate W&B runs for comparison.
+
+Usage:
+    python -m scripts.model_compare --policy_text_fixture <path> --denial_text_fixture <path> --models gpt-4.1-mini,gpt-4.1
+
+Requirements:
+    - WANDB_ENABLED=true in .env
+    - OPENAI_API_KEY set
+    - Fixtures in data/processed_safe/ and data/raw_denials/
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Dict, Any, List
+
+# Add project root to path
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.summarizer_frontier import build_denial_aware_report
+from src.wandb_telemetry import start_wandb_run, finish_wandb_run, evaluate_ag_structure
+from src.config import get_settings
+
+
+DEFAULT_POLICY_FIXTURE = PROJECT_ROOT / "data/processed_safe/HO3_TRUE_FL_2021.json"
+DEFAULT_DENIAL_FIXTURE = PROJECT_ROOT / "data/raw_denials/HO3_TRUE_FL_2021_denial.txt"
+DEFAULT_MODELS = ["gpt-4.1-mini"]
+
+
+def _parse_models(raw: str) -> List[str]:
+    return [m.strip() for m in raw.split(",") if m.strip()]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run model comparison with W&B telemetry per model.",
+    )
+    parser.add_argument(
+        "--policy_text_fixture",
+        default=str(DEFAULT_POLICY_FIXTURE),
+        help=(
+            "Path to policy summary JSON fixture (output of summarize_policy). "
+            f"Default: {DEFAULT_POLICY_FIXTURE}"
+        ),
+    )
+    parser.add_argument(
+        "--denial_text_fixture",
+        default=str(DEFAULT_DENIAL_FIXTURE),
+        help=(
+            "Path to denial text fixture. "
+            f"Default: {DEFAULT_DENIAL_FIXTURE}"
+        ),
+    )
+    parser.add_argument(
+        "--models",
+        default=",".join(DEFAULT_MODELS),
+        help="Comma-separated list of models to run.",
+    )
+    return parser.parse_args()
+
+
+def run_model_comparison() -> None:
+    """
+    Run dispute analysis with multiple models and compare via W&B.
+    """
+    args = parse_args()
+
+    policy_fixture = Path(args.policy_text_fixture)
+    denial_fixture = Path(args.denial_text_fixture)
+    models = _parse_models(args.models)
+
+    if not models:
+        print("[ERROR] No models provided. Use --models model_a,model_b")
+        sys.exit(1)
+
+    # Validate fixtures exist
+    if not policy_fixture.exists():
+        print(f"[ERROR] Policy fixture not found: {policy_fixture}")
+        sys.exit(1)
+    if not denial_fixture.exists():
+        print(f"[ERROR] Denial fixture not found: {denial_fixture}")
+        sys.exit(1)
+
+    # Load fixtures
+    policy_payload = json.loads(policy_fixture.read_text(encoding="utf-8"))
+    denial_text = denial_fixture.read_text(encoding="utf-8")
+
+    print(f"\n[MODEL COMPARISON RUNNER]")
+    print(f"=" * 60)
+    print(f"Policy fixture: {policy_fixture}")
+    print(f"Denial fixture: {denial_fixture}")
+    print(f"Models: {', '.join(models)}")
+    print(f"=" * 60)
+
+    settings = get_settings()
+    if not settings.wandb_enabled:
+        print("\n[WARNING] WANDB_ENABLED=false - runs will not be logged to W&B")
+        print("   Set WANDB_ENABLED=true in .env to enable telemetry\n")
+
+    results = []
+
+    for model in models:
+        print(f"\n[RUNNING] model: {model}")
+        print("-" * 60)
+
+        claim_id = f"model_compare_{model.replace('.', '_').replace('-', '_')}"
+
+        # Start W&B run with model-specific claim_id
+        start_wandb_run(
+            claim_id=claim_id,
+            mode="model_compare",
+            default_model=model,
+        )
+
+        try:
+            # Override model via environment (call_llm_json checks this)
+            original_model = os.environ.get("OPENAI_MODEL")
+            os.environ["OPENAI_MODEL"] = model
+
+            try:
+                # Run dispute analysis
+                dispute_report = build_denial_aware_report(policy_payload, denial_text)
+
+                # Evaluate A-G structure
+                quality_metrics = evaluate_ag_structure(dispute_report)
+
+                print(f"[SUCCESS] Completed: {model}")
+                print(f"   A-G sections present: {quality_metrics['quality/ag_present_count']}/7")
+                print(f"   A-G order OK: {quality_metrics['quality/ag_order_ok']}")
+
+                results.append({
+                    "model": model,
+                    "success": True,
+                    "quality": quality_metrics,
+                })
+
+            finally:
+                # Restore original model
+                if original_model is not None:
+                    os.environ["OPENAI_MODEL"] = original_model
+                else:
+                    os.environ.pop("OPENAI_MODEL", None)
+
+        except Exception as e:
+            print(f"[FAILED] Failed: {model}")
+            print(f"   Error: {e}")
+            results.append({
+                "model": model,
+                "success": False,
+                "error": str(e),
+            })
+
+        finally:
+            # Always finish W&B run
+            finish_wandb_run()
+
+    # Summary
+    print(f"\n{'=' * 60}")
+    print(f"[SUMMARY] Model Comparison Summary")
+    print(f"{'=' * 60}")
+
+    for result in results:
+        if result["success"]:
+            quality = result["quality"]
+            print(f"[OK] {result['model']:20s} | A-G: {quality['quality/ag_present_count']}/7 | Order: {quality['quality/ag_order_ok']}")
+        else:
+            print(f"[FAIL] {result['model']:20s} | Error: {result['error']}")
+
+    if settings.wandb_enabled:
+        print(f"\n[W&B] View runs in W&B: https://wandb.ai/{settings.wandb_entity}/{settings.wandb_project}")
+        print(f"   Filter by tag: mode=model_compare")
+    else:
+        print(f"\n[TIP] Enable W&B logging: WANDB_ENABLED=true in .env")
+
+    print()
+
+
+if __name__ == "__main__":
+    run_model_comparison()

--- a/src/demo_api.py
+++ b/src/demo_api.py
@@ -13,6 +13,7 @@ from .report_builder import (
 )
 from .summarizer_frontier import build_denial_aware_report
 from .config import get_settings
+from .wandb_telemetry import start_wandb_run, finish_wandb_run, evaluate_ag_structure
 
 
 UPLOAD_DIR = Path("data/uploads")
@@ -80,22 +81,29 @@ def run_policy_analysis(
 
     pdf_path = _save_uploaded_policy(policy_file_bytes, policy_filename)
 
-    # This runs your existing end-to-end pipeline (PDF -> sections -> LLM summaries -> JSON).
-    summary_json_path = summarize_policy(pdf_path)
+    # Start W&B run for policy analysis
+    start_wandb_run(
+        claim_id=pdf_path.stem,
+        mode="policy_only",
+    )
 
-    # Normalise into PolicyReport
-    summary_data = json.loads(summary_json_path.read_text(encoding="utf-8"))
-    policy_report = build_policy_report(summary_data)
+    try:
+        # This runs your existing end-to-end pipeline (PDF -> sections -> LLM summaries -> JSON).
+        summary_json_path = summarize_policy(pdf_path)
 
-    sections_substantive = _strip_raw_text(policy_report.sections_substantive)
-    sections_meta = _strip_raw_text(policy_report.sections_meta)
+        # Normalise into PolicyReport
+        summary_data = json.loads(summary_json_path.read_text(encoding="utf-8"))
+        policy_report = build_policy_report(summary_data)
 
-    # Build Markdown in-memory and also write it out next to the JSON summary.
-    markdown_text = render_markdown(policy_report)
-    md_path = summary_json_path.with_suffix(".report.md")
-    md_path.write_text(markdown_text, encoding="utf-8")
+        sections_substantive = _strip_raw_text(policy_report.sections_substantive)
+        sections_meta = _strip_raw_text(policy_report.sections_meta)
 
-    return {
+        # Build Markdown in-memory and also write it out next to the JSON summary.
+        markdown_text = render_markdown(policy_report)
+        md_path = summary_json_path.with_suffix(".report.md")
+        md_path.write_text(markdown_text, encoding="utf-8")
+
+        return {
         "policy_name": policy_report.policy_name,
         "source_path": policy_report.source_path,
         "stats": {
@@ -113,7 +121,10 @@ def run_policy_analysis(
             "persist_raw_text": settings.persist_raw_text,
         },
         "markdown": markdown_text,
-    }
+        }
+    finally:
+        # Always finish W&B run and log rollups
+        finish_wandb_run()
 
 
 def run_dispute_analysis(
@@ -147,45 +158,56 @@ def run_dispute_analysis(
     """
     settings = get_settings()
 
-    policy_path = Path(policy_summary_json_path)
-    if not policy_path.is_file():
-        raise FileNotFoundError(
-            f"Policy summary JSON not found: {policy_path}")
-
-    policy_payload = json.loads(policy_path.read_text(encoding="utf-8"))
-
-    # Call LLM-based builder (policy summary + denial text -> DisputeReport dataclass)
-    dispute_report = build_denial_aware_report(policy_payload, denial_text)
-
-    # Attach simple metadata (same pattern as run_denial_summary.py)
-    policy_id = policy_payload.get("policy_id") or policy_path.stem
+    # Generate claim_id for W&B run
     if denial_id is None:
-        # Fallback: timestamped ID if UI doesn’t supply something better
         denial_id = f"denial_{int(time.time())}"
 
-    dispute_report.policy_id = policy_id
-    dispute_report.denial_id = denial_id
-
-    # Decide where to write outputs
-    output_dir = _resolve_dispute_output_dir()
-    output_dir.mkdir(parents=True, exist_ok=True)
-    base_name = f"{policy_id}__{denial_id}.dispute"
-
-    json_out = output_dir / f"{base_name}.json"
-    md_out = output_dir / f"{base_name}.md"
-
-    # Persist JSON version of the dispute report
-    dispute_dict = dispute_report.to_dict()
-    json_out.write_text(
-        json.dumps(dispute_dict, indent=2, ensure_ascii=False),
-        encoding="utf-8",
+    # Start W&B run for dispute analysis
+    start_wandb_run(
+        claim_id=denial_id,
+        mode="dispute",
     )
 
-    # Render and persist Markdown
-    md_text = render_dispute_markdown(dispute_report)
-    md_out.write_text(md_text, encoding="utf-8")
+    try:
+        policy_path = Path(policy_summary_json_path)
+        if not policy_path.is_file():
+            raise FileNotFoundError(
+                f"Policy summary JSON not found: {policy_path}")
 
-    return {
+        policy_payload = json.loads(policy_path.read_text(encoding="utf-8"))
+
+        # Call LLM-based builder (policy summary + denial text -> DisputeReport dataclass)
+        dispute_report = build_denial_aware_report(policy_payload, denial_text)
+
+        # Evaluate A-G structure and log quality metrics
+        evaluate_ag_structure(dispute_report)
+
+        # Attach simple metadata (same pattern as run_denial_summary.py)
+        policy_id = policy_payload.get("policy_id") or policy_path.stem
+
+        dispute_report.policy_id = policy_id
+        dispute_report.denial_id = denial_id
+
+        # Decide where to write outputs
+        output_dir = _resolve_dispute_output_dir()
+        output_dir.mkdir(parents=True, exist_ok=True)
+        base_name = f"{policy_id}__{denial_id}.dispute"
+
+        json_out = output_dir / f"{base_name}.json"
+        md_out = output_dir / f"{base_name}.md"
+
+        # Persist JSON version of the dispute report
+        dispute_dict = dispute_report.to_dict()
+        json_out.write_text(
+            json.dumps(dispute_dict, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        # Render and persist Markdown
+        md_text = render_dispute_markdown(dispute_report)
+        md_out.write_text(md_text, encoding="utf-8")
+
+        return {
         "policy_id": policy_id,
         "denial_id": denial_id,
         "dispute_report": dispute_dict,
@@ -196,4 +218,7 @@ def run_dispute_analysis(
             "policy_summary_json": str(policy_path),
             "safe_mode": settings.safe_mode,
         },
-    }
+        }
+    finally:
+        # Always finish W&B run and log rollups
+        finish_wandb_run()

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -90,12 +90,14 @@ def call_llm_json(
 
             # Log successful call
             total_tokens = response.usage.total_tokens
+            prompt_tokens = response.usage.prompt_tokens
+            completion_tokens = response.usage.completion_tokens
             _log_to_wandb({
                 "llm/model": model_name,
                 "llm/stage": stage or "unknown",
                 "llm/latency_ms": latency_ms,
-                "llm/prompt_tokens": response.usage.prompt_tokens,
-                "llm/completion_tokens": response.usage.completion_tokens,
+                "llm/prompt_tokens": prompt_tokens,
+                "llm/completion_tokens": completion_tokens,
                 "llm/total_tokens": total_tokens,
                 "llm/temperature": temperature,
                 "llm/attempt": attempt,
@@ -106,7 +108,14 @@ def call_llm_json(
             # Record to run tracker if active
             tracker = get_run_tracker()
             if tracker is not None:
-                tracker.record_call(stage, latency_ms, total_tokens, success=True)
+                tracker.record_call(
+                    stage,
+                    latency_ms,
+                    total_tokens,
+                    success=True,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                )
 
             return parsed
 
@@ -116,6 +125,9 @@ def call_llm_json(
                 "llm/model": model_name,
                 "llm/stage": stage or "unknown",
                 "llm/latency_ms": latency_ms,
+                "llm/prompt_tokens": 0,
+                "llm/completion_tokens": 0,
+                "llm/total_tokens": 0,
                 "llm/temperature": temperature,
                 "llm/attempt": attempt,
                 "llm/success": False,
@@ -143,6 +155,9 @@ def call_llm_json(
                 "llm/model": model_name,
                 "llm/stage": stage or "unknown",
                 "llm/latency_ms": latency_ms,
+                "llm/prompt_tokens": 0,
+                "llm/completion_tokens": 0,
+                "llm/total_tokens": 0,
                 "llm/temperature": temperature,
                 "llm/attempt": attempt,
                 "llm/success": False,

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional
 
 from openai import OpenAI
 from .config import get_settings, ConfigError
+from .wandb_telemetry import get_run_tracker
 
 # Optional wandb import - gracefully handle if not installed
 try:
@@ -18,9 +19,6 @@ except ImportError:
     wandb = None
     _WANDB_AVAILABLE = False
 
-# Module-level wandb run state
-_wandb_run = None
-
 
 @dataclass
 class LLMCallError(RuntimeError):
@@ -28,26 +26,16 @@ class LLMCallError(RuntimeError):
     last_response: Optional[str] = None
 
 
-def _init_wandb() -> None:
-    """Initialize wandb run if enabled and not already initialized."""
-    global _wandb_run
-    if _wandb_run is not None:
-        return
+def _log_to_wandb(metrics: Dict[str, Any]) -> None:
+    """
+    Log metrics to wandb if a run is active.
+
+    IMPORTANT: Only logs if wandb.run is not None.
+    All wandb.init() calls must go through wandb_telemetry.start_wandb_run().
+    """
     if not _WANDB_AVAILABLE:
         return
-    settings = get_settings()
-    if not settings.wandb_enabled:
-        return
-    _wandb_run = wandb.init(
-        project=settings.wandb_project,
-        entity=settings.wandb_entity,
-        config={"model": settings.openai_model},
-    )
-
-
-def _log_to_wandb(metrics: Dict[str, Any]) -> None:
-    """Log metrics to wandb if initialized."""
-    if _wandb_run is not None:
+    if wandb.run is not None:
         wandb.log(metrics)
 
 
@@ -66,6 +54,7 @@ def call_llm_json(
     max_retries: int = 3,
     timeout: float = 30.0,
     model: Optional[str] = None,
+    stage: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Call the LLM expecting a JSON object.
@@ -73,10 +62,8 @@ def call_llm_json(
     - Uses OpenAI chat.completions API.
     - Retries on transient errors and JSON decode failures.
     - Raises LLMCallError with the last raw response text on final failure.
-    - Logs metrics to wandb if enabled.
+    - Logs metrics to wandb if a run is active (via wandb_telemetry.start_wandb_run).
     """
-    _init_wandb()
-
     last_raw: Optional[str] = None
     model_name = model or _get_model_name()
 
@@ -102,17 +89,24 @@ def call_llm_json(
             parsed = json.loads(raw)
 
             # Log successful call
+            total_tokens = response.usage.total_tokens
             _log_to_wandb({
                 "llm/model": model_name,
+                "llm/stage": stage or "unknown",
                 "llm/latency_ms": latency_ms,
                 "llm/prompt_tokens": response.usage.prompt_tokens,
                 "llm/completion_tokens": response.usage.completion_tokens,
-                "llm/total_tokens": response.usage.total_tokens,
+                "llm/total_tokens": total_tokens,
                 "llm/temperature": temperature,
                 "llm/attempt": attempt,
                 "llm/success": True,
                 "llm/error_type": None,
             })
+
+            # Record to run tracker if active
+            tracker = get_run_tracker()
+            if tracker is not None:
+                tracker.record_call(stage, latency_ms, total_tokens, success=True)
 
             return parsed
 
@@ -120,12 +114,17 @@ def call_llm_json(
             latency_ms = (time.time() - start_time) * 1000
             _log_to_wandb({
                 "llm/model": model_name,
+                "llm/stage": stage or "unknown",
                 "llm/latency_ms": latency_ms,
                 "llm/temperature": temperature,
                 "llm/attempt": attempt,
                 "llm/success": False,
                 "llm/error_type": "json_decode_error",
             })
+            # Record error to run tracker
+            tracker = get_run_tracker()
+            if tracker is not None:
+                tracker.record_call(stage, latency_ms, 0, success=False)
             # Model returned non-JSON; retry unless we're out of attempts.
             if attempt == max_retries:
                 raise LLMCallError(
@@ -142,12 +141,17 @@ def call_llm_json(
             latency_ms = (time.time() - start_time) * 1000
             _log_to_wandb({
                 "llm/model": model_name,
+                "llm/stage": stage or "unknown",
                 "llm/latency_ms": latency_ms,
                 "llm/temperature": temperature,
                 "llm/attempt": attempt,
                 "llm/success": False,
                 "llm/error_type": type(e).__name__,
             })
+            # Record error to run tracker
+            tracker = get_run_tracker()
+            if tracker is not None:
+                tracker.record_call(stage, latency_ms, 0, success=False)
             if attempt == max_retries:
                 raise LLMCallError(
                     message=f"LLM call failed after retries: {e}",

--- a/src/summarizer_frontier.py
+++ b/src/summarizer_frontier.py
@@ -63,6 +63,7 @@ def summarize_section(section_name: str, section_text: str) -> SectionSummary:
         temperature=0.2,
         max_retries=3,
         timeout=30.0,
+        stage="section_summary",
     )
 
     return SectionSummary(
@@ -262,6 +263,7 @@ def build_denial_aware_report(
         temperature=0.2,
         max_retries=3,
         timeout=60.0,
+        stage="dispute_report",
     )
 
     plain_summary = str(data.get("plain_summary", "") or "").strip()

--- a/src/wandb_telemetry.py
+++ b/src/wandb_telemetry.py
@@ -34,6 +34,8 @@ class WandbRunTracker:
     Accumulates metrics across all LLM calls in a single claim run.
     """
     total_tokens: int = 0
+    total_prompt_tokens: int = 0
+    total_completion_tokens: int = 0
     total_latency_ms: float = 0.0
     call_count: int = 0
     error_count: int = 0
@@ -44,11 +46,15 @@ class WandbRunTracker:
         latency_ms: float,
         tokens: int,
         success: bool,
+        prompt_tokens: int = 0,
+        completion_tokens: int = 0,
     ) -> None:
         """Record metrics from a single LLM call."""
         self.call_count += 1
         self.total_latency_ms += latency_ms
         self.total_tokens += tokens
+        self.total_prompt_tokens += prompt_tokens
+        self.total_completion_tokens += completion_tokens
         if not success:
             self.error_count += 1
 
@@ -76,6 +82,7 @@ def start_wandb_run(
     claim_id: str,
     mode: str,
     git_commit: Optional[str] = None,
+    default_model: Optional[str] = None,
 ) -> None:
     """
     Initialize a W&B run with claim-level context.
@@ -96,6 +103,8 @@ def start_wandb_run(
 
     if git_commit is None:
         git_commit = _get_git_commit()
+    if default_model is None:
+        default_model = settings.openai_model
 
     # Initialize tracker
     _run_tracker = WandbRunTracker()
@@ -110,7 +119,7 @@ def start_wandb_run(
             "run/git_commit": git_commit,
             "run/safe_mode": settings.safe_mode,
             "run/persist_raw_text": settings.persist_raw_text,
-            "run/default_model": settings.openai_model,
+            "run/default_model": default_model,
         },
         # Allow multiple runs in same process (for testing/batch scenarios)
         reinit=True,
@@ -135,6 +144,8 @@ def finish_wandb_run() -> None:
         # Log rollup metrics
         wandb.log({
             "run/total_tokens": _run_tracker.total_tokens,
+            "run/total_prompt_tokens": _run_tracker.total_prompt_tokens,
+            "run/total_completion_tokens": _run_tracker.total_completion_tokens,
             "run/total_latency_ms": _run_tracker.total_latency_ms,
             "run/calls": _run_tracker.call_count,
             "run/errors": _run_tracker.error_count,

--- a/src/wandb_telemetry.py
+++ b/src/wandb_telemetry.py
@@ -1,0 +1,206 @@
+# src/wandb_telemetry.py
+"""
+W&B run-level telemetry management for claim-level analysis.
+
+Responsibilities:
+- Initialize and finalize W&B runs with claim context
+- Track and rollup per-run metrics (tokens, latency, calls, errors)
+- Evaluate A-G report structure quality (metrics only, no raw text)
+"""
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from typing import Optional, Dict, Any
+
+from .config import get_settings
+
+# Optional wandb import
+try:
+    import wandb
+    _WANDB_AVAILABLE = True
+except ImportError:
+    wandb = None
+    _WANDB_AVAILABLE = False
+
+
+# Module-level tracker instance
+_run_tracker: Optional[WandbRunTracker] = None
+
+
+@dataclass
+class WandbRunTracker:
+    """
+    Accumulates metrics across all LLM calls in a single claim run.
+    """
+    total_tokens: int = 0
+    total_latency_ms: float = 0.0
+    call_count: int = 0
+    error_count: int = 0
+
+    def record_call(
+        self,
+        stage: Optional[str],
+        latency_ms: float,
+        tokens: int,
+        success: bool,
+    ) -> None:
+        """Record metrics from a single LLM call."""
+        self.call_count += 1
+        self.total_latency_ms += latency_ms
+        self.total_tokens += tokens
+        if not success:
+            self.error_count += 1
+
+
+def _get_git_commit() -> str:
+    """
+    Get current git commit hash (short form).
+    Returns 'unknown' if git is unavailable or fails.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()[:8]
+    except Exception:
+        pass
+    return "unknown"
+
+
+def start_wandb_run(
+    claim_id: str,
+    mode: str,
+    git_commit: Optional[str] = None,
+) -> None:
+    """
+    Initialize a W&B run with claim-level context.
+
+    Args:
+        claim_id: Unique identifier for this claim/analysis run
+        mode: Run mode ("policy_only", "dispute", "demo")
+        git_commit: Git commit hash (auto-detected if None)
+    """
+    global _run_tracker
+
+    if not _WANDB_AVAILABLE:
+        return
+
+    settings = get_settings()
+    if not settings.wandb_enabled:
+        return
+
+    if git_commit is None:
+        git_commit = _get_git_commit()
+
+    # Initialize tracker
+    _run_tracker = WandbRunTracker()
+
+    # Initialize W&B run with context
+    wandb.init(
+        project=settings.wandb_project,
+        entity=settings.wandb_entity,
+        config={
+            "run/claim_id": claim_id,
+            "run/mode": mode,
+            "run/git_commit": git_commit,
+            "run/safe_mode": settings.safe_mode,
+            "run/persist_raw_text": settings.persist_raw_text,
+            "run/default_model": settings.openai_model,
+        },
+        # Allow multiple runs in same process (for testing/batch scenarios)
+        reinit=True,
+    )
+
+
+def get_run_tracker() -> Optional[WandbRunTracker]:
+    """Get the current run tracker (if a run is active)."""
+    return _run_tracker
+
+
+def finish_wandb_run() -> None:
+    """
+    Log per-run rollups and close the W&B run.
+    """
+    global _run_tracker
+
+    if not _WANDB_AVAILABLE or wandb.run is None:
+        return
+
+    if _run_tracker is not None:
+        # Log rollup metrics
+        wandb.log({
+            "run/total_tokens": _run_tracker.total_tokens,
+            "run/total_latency_ms": _run_tracker.total_latency_ms,
+            "run/calls": _run_tracker.call_count,
+            "run/errors": _run_tracker.error_count,
+        })
+
+    # Close the run
+    wandb.finish()
+
+    # Reset tracker
+    _run_tracker = None
+
+
+def _is_non_empty(value: Any) -> bool:
+    """
+    Check if a value is non-empty (for A-G section presence detection).
+
+    - Strings: non-empty after stripping
+    - Lists: non-empty
+    - Objects with attributes: considered present
+    - None: empty
+    """
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return len(value.strip()) > 0
+    if isinstance(value, list):
+        return len(value) > 0
+    # Dataclass instances / dicts are considered "present"
+    return True
+
+
+def evaluate_ag_structure(dispute_report: Any) -> Dict[str, Any]:
+    """
+    Evaluate A-G report structure quality.
+
+    Returns metrics only (NO raw text logged to W&B).
+
+    Args:
+        dispute_report: DisputeReport instance
+
+    Returns:
+        Dict with:
+          - quality/ag_present_count: Number of non-empty A-G sections (0-7)
+          - quality/ag_order_ok: True if all 7 sections are present
+    """
+    # A-G sections in order
+    sections = [
+        ("A", dispute_report.plain_summary),
+        ("B", dispute_report.coverage_highlights),
+        ("C", dispute_report.exclusions_limitations),
+        ("D", dispute_report.denial_reasons),
+        ("E", dispute_report.dispute_angles),
+        ("F", dispute_report.missing_info),
+        ("G", dispute_report.confidence),
+    ]
+
+    present_count = sum(1 for _, val in sections if _is_non_empty(val))
+    order_ok = present_count == 7  # All sections present
+
+    metrics = {
+        "quality/ag_present_count": present_count,
+        "quality/ag_order_ok": order_ok,
+    }
+
+    # Log to W&B if run is active
+    if _WANDB_AVAILABLE and wandb.run is not None:
+        wandb.log(metrics)
+
+    return metrics


### PR DESCRIPTION
## Summary
Adds deterministic W&B lifecycle + run-level rollups, plus a model comparison runner to benchmark latency/tokens/quality across models.

## What changed
- Deterministic W&B init/finish lifecycle (single source of truth)
- Run-level rollups:
  - `run/total_tokens`, `run/total_latency_ms`, `run/calls`, `run/errors`
- A–G structure quality metrics (privacy-safe):
  - `quality/ag_present_count`, `quality/ag_order_ok`
- New: `scripts/model_compare.py` to run the same fixture through multiple models and create separate W&B runs
- Fix: don’t print `wandb.ai/None/...` when `WANDB_ENTITY` isn’t set
- Session log updated with test results + restart steps

## How to test
### Streamlit (end-to-end)
1. Set env:
   - `WANDB_ENABLED=true`
   - `SAFE_MODE=true`
2. Run:
   - `streamlit run frontend/app.py`
3. Upload fixture policy + denial and run analysis
4. Confirm no W&B lifecycle errors and that run shows config + metrics + rollups.

### Model compare
- `python -m scripts.model_compare --models gpt-4o-mini,gpt-4.1-mini,gpt-4o`
- Check W&B runs filtered by `mode=model_compare`

## Notes
For deterministic project links, set:
- `WANDB_ENTITY=itprodirect`
- `WANDB_PROJECT=policy-dispute-ai`