### PR TITLE
Fix Demo Mode with tracked demo assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ The repo’s GitHub PR and issues contain screenshots of:
 
 ```text
 policy-dispute-ai-assistant/
+├─ assets/
+│  └─ demo/                 # Tracked offline demo dispute bundle
+│
 ├─ src/
 │  ├─ config.py              # Env + safety flags (SAFE_MODE, PERSIST_RAW_TEXT, etc.)
 │  ├─ llm_client.py          # Thin wrapper around OpenAI Responses API
@@ -77,7 +80,7 @@ policy-dispute-ai-assistant/
 │  └─ app_v0_minimul.py      # Original single-page prototype (kept for reference)
 │
 ├─ data/
-│  ├─ processed/             # Sample JSON + Markdown outputs (checked in)
+│  ├─ processed/             # Local generated JSON + Markdown outputs (gitignored)
 │  └─ uploads/               # Local upload cache (gitignored)
 │
 ├─ notebooks/                # Experimental notebooks / scratchpads
@@ -149,6 +152,16 @@ streamlit run frontend/app.py
 ```
 
 This will start Streamlit on `http://localhost:8501`.
+
+### Demo Mode (offline)
+
+For a fresh-clone walkthrough with zero API calls, toggle **Demo Mode (offline)** in the sidebar.
+The bundled demo-safe dispute report lives in:
+
+- `assets/demo/demo.json`
+- `assets/demo/demo.report.md`
+
+These tracked files are deterministic demo artifacts, not real client claim data.
 
 ### New claim flow
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -29,8 +29,8 @@ Goal: Run the full demo with **zero API calls**.
 
 Deterministic demo files live here:
 
-- `data/processed/demo/demo.json`
-- `data/processed/demo/demo.report.md`
+- `assets/demo/demo.json`
+- `assets/demo/demo.report.md`
 
 ### Steps
 
@@ -41,14 +41,12 @@ Deterministic demo files live here:
 
 ### If demo assets are missing
 
-Use one of the sample pairs in `data/processed/` and copy them into:
+The demo assets are tracked in the repository. Restore these files from git:
 
-- `data/processed/demo/demo.json`
-- `data/processed/demo/demo.report.md`
+- `assets/demo/demo.json`
+- `assets/demo/demo.report.md`
 
-Primary recommended source:
-
-- `HO3_ISO_1999_III_SAMPLE__1768603155` + `.report`
+Do not rebuild this bundle from real client claim data.
 
 ---
 
@@ -69,8 +67,8 @@ Primary recommended source:
 ### Streamlit boots but errors when demo mode is on
 
 - Confirm both files exist:
-  - `data/processed/demo/demo.json`
-  - `data/processed/demo/demo.report.md`
+  - `assets/demo/demo.json`
+  - `assets/demo/demo.report.md`
 
 ### Live mode fails due to missing key
 

--- a/assets/demo/demo.json
+++ b/assets/demo/demo.json
@@ -1,0 +1,126 @@
+{
+  "policy_id": "HO3_USAA_TX_OPIC_2008",
+  "denial_id": "HO3_TRUE_FL_2021_denial",
+  "plain_summary": "The insureds reported water damage to their kitchen and living room nearly a month after the loss occurred. The insurer denied the claim citing late notice, damage caused by long-term leakage and wear and tear, pre-existing damage, failure to protect the property from further damage, and that the covered loss amount is below the deductible. The dispute centers on whether the damage qualifies as a covered sudden and accidental loss and whether policy conditions regarding notice and property protection were met.",
+  "coverage_highlights": [
+    {
+      "text": "Coverage for sudden and accidental direct physical damage to tangible property under Coverage A - Dwelling Protection.",
+      "citation": "COVERAGE A - DWELLING PROTECTION EXCEPT AS SPECIFICALLY PROVIDED IN SECTION I -"
+    },
+    {
+      "text": "Coverage for reasonable and necessary repairs to protect property from further damage after a covered loss under Additional Coverages.",
+      "citation": "ADDITIONAL COVERAGES"
+    },
+    {
+      "text": "Coverage for water damage caused by sudden and accidental discharge of water, subject to exclusions and conditions.",
+      "citation": "PROTECTION AND PERSONAL PROPERTY; DWELLING PROTECTION AND OTHER"
+    }
+  ],
+  "exclusions_limitations": [
+    {
+      "text": "Exclusion of loss caused by wear and tear, deterioration, and continuous or repeated seepage or leakage of water over time.",
+      "citation": "LOSSES WE DO NOT COVER UNDER DWELLING PROTECTION AND OTHER STRUCTURES"
+    },
+    {
+      "text": "Requirement for prompt notice of loss and cooperation with insurer’s investigation; late notice may result in denial.",
+      "citation": "COVERAGE F - OR YOUR LOSS IF YOU FAIL TO; CONDITIONS"
+    },
+    {
+      "text": "Obligation of insured to protect property from further damage and make reasonable repairs after loss.",
+      "citation": "COVERAGE F - OR YOUR LOSS IF YOU FAIL TO; ADDITIONAL COVERAGES"
+    },
+    {
+      "text": "Application of deductible to losses; insurer pays only amounts exceeding deductible.",
+      "citation": "DEDUCTIBLE"
+    }
+  ],
+  "denial_reasons": [
+    {
+      "text": "Late notice of the loss prevented timely inspection and investigation, prejudicing the insurer.",
+      "citation": "COVERAGE F - OR YOUR LOSS IF YOU FAIL TO (Duties After Loss and Conditions sections)"
+    },
+    {
+      "text": "Damage resulted from long-term leakage and wear and tear, which are excluded under the policy.",
+      "citation": "LOSSES WE DO NOT COVER UNDER DWELLING PROTECTION AND OTHER STRUCTURES"
+    },
+    {
+      "text": "Some damage pre-existed the reported loss and the insured failed to take reasonable steps to protect the property from further damage.",
+      "citation": "COVERAGE F - OR YOUR LOSS IF YOU FAIL TO; CONDITIONS"
+    },
+    {
+      "text": "The estimated covered damage after depreciation and exclusions is below the policy deductible, so no payment is owed.",
+      "citation": "DEDUCTIBLE"
+    }
+  ],
+  "dispute_angles": [
+    {
+      "text": "Whether the insured provided notice of loss within a reasonable or required timeframe and if late notice prejudiced the insurer.",
+      "citations": [
+        "COVERAGE F - OR YOUR LOSS IF YOU FAIL TO",
+        "CONDITIONS"
+      ]
+    },
+    {
+      "text": "Whether the water damage was caused by a sudden and accidental event or by long-term leakage and wear and tear excluded by the policy.",
+      "citations": [
+        "LOSSES WE DO NOT COVER UNDER DWELLING PROTECTION AND OTHER STRUCTURES",
+        "PROTECTION AND PERSONAL PROPERTY"
+      ]
+    },
+    {
+      "text": "Whether any damage pre-existed the loss date and how pre-existing damage affects coverage.",
+      "citations": [
+        "COVERAGE F - OR YOUR LOSS IF YOU FAIL TO",
+        "CONDITIONS"
+      ]
+    },
+    {
+      "text": "Whether the insured took reasonable and necessary steps to protect the property from further damage after the loss.",
+      "citations": [
+        "ADDITIONAL COVERAGES",
+        "COVERAGE F - OR YOUR LOSS IF YOU FAIL TO"
+      ]
+    },
+    {
+      "text": "Whether the estimated covered damage exceeds the deductible after depreciation and exclusions.",
+      "citations": [
+        "DEDUCTIBLE"
+      ]
+    },
+    {
+      "text": "Clarification of what constitutes 'wear and tear' and 'long-term leakage' versus sudden accidental discharge of water.",
+      "citations": [
+        "DEFINITIONS",
+        "LOSSES WE DO NOT COVER UNDER DWELLING PROTECTION AND OTHER STRUCTURES"
+      ]
+    },
+    {
+      "text": "Whether microbial damage or mold resulting from water intrusion is covered if caused by a covered peril.",
+      "citations": [
+        "SECTION I - LOSSES WE DO NOT COVER 1.I. MICROBIAL ORGANISMS , INCLUDING BUT NOT"
+      ]
+    }
+  ],
+  "missing_info": [
+    "Exact date and manner of initial notice to insurer by the insured.",
+    "Detailed timeline and documentation of any emergency mitigation or repairs performed after the loss.",
+    "Complete plumber’s report and inspection findings with photos and dates.",
+    "Home inspection report and contractor estimates showing pre-existing damage.",
+    "Policy declarations page showing deductible amounts and coverage limits.",
+    "Any correspondence or communications between insured and insurer regarding the claim.",
+    "Detailed inventory or proof of damaged property and repair estimates.",
+    "Policy endorsements or amendments that might affect water damage or notice requirements."
+  ],
+  "confidence": {
+    "score": 0.9,
+    "notes": "The denial letter clearly cites policy conditions and exclusions that align with the summarized policy sections. The main issues of late notice, wear and tear exclusion, pre-existing damage, and deductible application are well supported by the policy summaries. However, some ambiguity remains regarding the exact timing and nature of the loss and insured actions, which affects certainty.",
+    "verify_clauses": [
+      "COVERAGE F - OR YOUR LOSS IF YOU FAIL TO",
+      "LOSSES WE DO NOT COVER UNDER DWELLING PROTECTION AND OTHER STRUCTURES",
+      "DEDUCTIBLE",
+      "ADDITIONAL COVERAGES",
+      "PROTECTION AND PERSONAL PROPERTY",
+      "SECTION I - LOSSES WE DO NOT COVER 1.I. MICROBIAL ORGANISMS , INCLUDING BUT NOT"
+    ]
+  }
+}

--- a/assets/demo/demo.report.md
+++ b/assets/demo/demo.report.md
@@ -1,0 +1,71 @@
+# Policy dispute summary
+
+- Policy: `HO3_USAA_TX_OPIC_2008`
+- Denial: `HO3_TRUE_FL_2021_denial`
+
+> **Framing:** This is an AI-generated analysis of policy language and a denial letter.
+> It is *not* legal advice and does not create coverage, rights, or an attorney–client relationship.
+
+## A. Plain-English overview of the dispute
+
+The insureds reported water damage to their kitchen and living room nearly a month after the loss occurred. The insurer denied the claim citing late notice, damage caused by long-term leakage and wear and tear, pre-existing damage, failure to protect the property from further damage, and that the covered loss amount is below the deductible. The dispute centers on whether the damage qualifies as a covered sudden and accidental loss and whether policy conditions regarding notice and property protection were met.
+
+## B. Coverage highlights that may support the insured
+
+- Coverage for sudden and accidental direct physical damage to tangible property under Coverage A - Dwelling Protection. (COVERAGE A - DWELLING PROTECTION EXCEPT AS SPECIFICALLY PROVIDED IN SECTION I -)
+- Coverage for reasonable and necessary repairs to protect property from further damage after a covered loss under Additional Coverages. (ADDITIONAL COVERAGES)
+- Coverage for water damage caused by sudden and accidental discharge of water, subject to exclusions and conditions. (PROTECTION AND PERSONAL PROPERTY; DWELLING PROTECTION AND OTHER)
+
+## C. Key exclusions / limitations that may hurt the insured
+
+- Exclusion of loss caused by wear and tear, deterioration, and continuous or repeated seepage or leakage of water over time. (LOSSES WE DO NOT COVER UNDER DWELLING PROTECTION AND OTHER STRUCTURES)
+- Requirement for prompt notice of loss and cooperation with insurer’s investigation; late notice may result in denial. (COVERAGE F - OR YOUR LOSS IF YOU FAIL TO; CONDITIONS)
+- Obligation of insured to protect property from further damage and make reasonable repairs after loss. (COVERAGE F - OR YOUR LOSS IF YOU FAIL TO; ADDITIONAL COVERAGES)
+- Application of deductible to losses; insurer pays only amounts exceeding deductible. (DEDUCTIBLE)
+
+## D. Denial reasons (as stated or implied by the insurer)
+
+- Late notice of the loss prevented timely inspection and investigation, prejudicing the insurer. (COVERAGE F - OR YOUR LOSS IF YOU FAIL TO (Duties After Loss and Conditions sections))
+- Damage resulted from long-term leakage and wear and tear, which are excluded under the policy. (LOSSES WE DO NOT COVER UNDER DWELLING PROTECTION AND OTHER STRUCTURES)
+- Some damage pre-existed the reported loss and the insured failed to take reasonable steps to protect the property from further damage. (COVERAGE F - OR YOUR LOSS IF YOU FAIL TO; CONDITIONS)
+- The estimated covered damage after depreciation and exclusions is below the policy deductible, so no payment is owed. (DEDUCTIBLE)
+
+## E. Possible dispute angles to explore (not legal advice)
+
+- Whether the insured provided notice of loss within a reasonable or required timeframe and if late notice prejudiced the insurer.  
+  _Citations: COVERAGE F - OR YOUR LOSS IF YOU FAIL TO, CONDITIONS_
+- Whether the water damage was caused by a sudden and accidental event or by long-term leakage and wear and tear excluded by the policy.  
+  _Citations: LOSSES WE DO NOT COVER UNDER DWELLING PROTECTION AND OTHER STRUCTURES, PROTECTION AND PERSONAL PROPERTY_
+- Whether any damage pre-existed the loss date and how pre-existing damage affects coverage.  
+  _Citations: COVERAGE F - OR YOUR LOSS IF YOU FAIL TO, CONDITIONS_
+- Whether the insured took reasonable and necessary steps to protect the property from further damage after the loss.  
+  _Citations: ADDITIONAL COVERAGES, COVERAGE F - OR YOUR LOSS IF YOU FAIL TO_
+- Whether the estimated covered damage exceeds the deductible after depreciation and exclusions.  
+  _Citations: DEDUCTIBLE_
+- Clarification of what constitutes 'wear and tear' and 'long-term leakage' versus sudden accidental discharge of water.  
+  _Citations: DEFINITIONS, LOSSES WE DO NOT COVER UNDER DWELLING PROTECTION AND OTHER STRUCTURES_
+- Whether microbial damage or mold resulting from water intrusion is covered if caused by a covered peril.  
+  _Citations: SECTION I - LOSSES WE DO NOT COVER 1.I. MICROBIAL ORGANISMS , INCLUDING BUT NOT_
+
+## F. Missing information / suggested next steps
+
+- Exact date and manner of initial notice to insurer by the insured.
+- Detailed timeline and documentation of any emergency mitigation or repairs performed after the loss.
+- Complete plumber’s report and inspection findings with photos and dates.
+- Home inspection report and contractor estimates showing pre-existing damage.
+- Policy declarations page showing deductible amounts and coverage limits.
+- Any correspondence or communications between insured and insurer regarding the claim.
+- Detailed inventory or proof of damaged property and repair estimates.
+- Policy endorsements or amendments that might affect water damage or notice requirements.
+
+## G. Confidence and clauses to verify
+
+- **Confidence score (0–1):** 0.90
+- **Notes:** The denial letter clearly cites policy conditions and exclusions that align with the summarized policy sections. The main issues of late notice, wear and tear exclusion, pre-existing damage, and deductible application are well supported by the policy summaries. However, some ambiguity remains regarding the exact timing and nature of the loss and insured actions, which affects certainty.
+- **Clauses / sections to double-check:**
+  - COVERAGE F - OR YOUR LOSS IF YOU FAIL TO
+  - LOSSES WE DO NOT COVER UNDER DWELLING PROTECTION AND OTHER STRUCTURES
+  - DEDUCTIBLE
+  - ADDITIONAL COVERAGES
+  - PROTECTION AND PERSONAL PROPERTY
+  - SECTION I - LOSSES WE DO NOT COVER 1.I. MICROBIAL ORGANISMS , INCLUDING BUT NOT

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -50,7 +50,7 @@ SESSION_KEY_SELECTED_CLAIM = "selected_claim_id"
 SESSION_KEY_SECTION_MAP = "section_text_map"
 SESSION_KEY_DEMO_MODE = "demo_mode"
 
-DEMO_ASSET_DIR = Path("data/processed/demo")
+DEMO_ASSET_DIR = ROOT / "assets" / "demo"
 DEMO_JSON_PATH = DEMO_ASSET_DIR / "demo.json"
 DEMO_MD_PATH = DEMO_ASSET_DIR / "demo.report.md"
 
@@ -73,16 +73,10 @@ def _save_denial_pdf(uploaded_file, claim_nickname: str | None = None) -> Path:
 
 def _demo_asset_instructions() -> str:
     return (
-        "Demo assets not found. Create them by copying a known sample:\n"
-        "1) data/processed/HO3_ISO_1999_III_SAMPLE__1768603155.json -> "
-        "data/processed/demo/demo.json\n"
-        "2) data/processed/HO3_ISO_1999_III_SAMPLE__1768603155.report.md -> "
-        "data/processed/demo/demo.report.md\n"
-        "Alternate (dispute report only):\n"
-        "1) data/processed/HO3_USAA_TX_OPIC_2008__HO3_TRUE_FL_2021_denial.dispute.json -> "
-        "data/processed/demo/demo.json\n"
-        "2) data/processed/HO3_USAA_TX_OPIC_2008__HO3_TRUE_FL_2021_denial.dispute.md -> "
-        "data/processed/demo/demo.report.md"
+        "Demo assets not found. Expected tracked demo files at:\n"
+        f"1) {DEMO_JSON_PATH.relative_to(ROOT)}\n"
+        f"2) {DEMO_MD_PATH.relative_to(ROOT)}\n"
+        "Restore these files from the repository or see RUNBOOK.md for Demo Mode setup."
     )
 
 


### PR DESCRIPTION
## Summary
- ship the deterministic Demo Mode dispute bundle under `assets/demo/`
- point `frontend/app.py` Demo Mode loading at the tracked asset path instead of gitignored `data/processed/demo`
- update README/RUNBOOK demo instructions so fresh-clone setup uses files that exist in the repo

## Validation
- `python -m pytest -q` -> 20 passed
- `.venv\Scripts\python.exe -c "from frontend import app; p,d=app._load_demo_assets(); r=d.get('dispute_report',{}); print(app.DEMO_JSON_PATH.relative_to(app.ROOT)); print(r.get('policy_id'), r.get('denial_id'), r.get('confidence',{}).get('score'), len(r.get('denial_reasons') or []))"` -> `assets\demo\demo.json`, confidence `0.9`, 4 denial reasons
- `git check-ignore assets\demo\demo.json assets\demo\demo.report.md` -> assets are not ignored
- Demo asset shape checked with PowerShell JSON parsing: plain summary present, confidence 0.9, 4 denial reasons

## Scope notes
- Closes #10
- Does not implement sample PDF uploads or the `Try with sample claim` button from #11
- Does not include PDFs, raw policy text, or real client claim data
