### PR TITLE
Fix safe env defaults and pin dependencies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,9 @@ OPENAI_MODEL=gpt-4.1-mini
 # Data handling / privacy flags
 # In almost all real-world use, you should leave SAFE_MODE=true so raw
 # policy language is not persisted to disk.
+# When SAFE_MODE=true, raw text is stripped even if PERSIST_RAW_TEXT is changed.
 SAFE_MODE=true
-PERSIST_RAW_TEXT=true
+PERSIST_RAW_TEXT=false
 
 # Weights & Biases logging (optional)
 WANDB_ENABLED=false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-python-dotenv
-pypdf
-tiktoken          # optional but helpful if you want token-aware chunking
-openai           # new SDK style; adjust version if needed
-rich             # nice CLI output (optional but useful)
-streamlit
-wandb            # optional LLM call logging
-python-docx      # Word document export
+python-dotenv==1.2.1
+pypdf==6.4.0
+tiktoken==0.12.0          # optional but helpful if you want token-aware chunking
+openai==2.8.1
+rich==14.2.0              # nice CLI output (optional but useful)
+streamlit==1.52.1
+wandb==0.24.0             # optional LLM call logging
+python-docx==1.2.0        # Word document export


### PR DESCRIPTION
## Summary
- change `.env.example` to safe-by-default raw text persistence (`PERSIST_RAW_TEXT=false`)
- add a short note that `SAFE_MODE=true` strips raw text even if persistence is changed
- pin direct runtime dependencies in `requirements.txt` to the versions currently working in the repo venv

## Pinned direct dependencies
- python-dotenv==1.2.1
- pypdf==6.4.0
- tiktoken==0.12.0
- openai==2.8.1
- rich==14.2.0
- streamlit==1.52.1
- wandb==0.24.0
- python-docx==1.2.0

## Validation
- `python -m pytest -q` -> 20 passed
- `python -m venv env\issue24-clean2` -> created ignored validation venv
- `env\issue24-clean2\Scripts\python.exe -m pip install --disable-pip-version-check -r requirements.txt` -> succeeded
- `env\issue24-clean2\Scripts\python.exe -c "import streamlit"` -> passed
- `env\issue24-clean2\Scripts\python.exe -c "import openai"` -> passed
- `env\issue24-clean2\Scripts\python.exe -c "import pypdf"` -> passed
- `env\issue24-clean2\Scripts\python.exe -c "import docx"` -> passed
- `env\issue24-clean2\Scripts\python.exe -c "import dotenv"` -> passed
- `git diff --check` -> passed

## Notes
- Closes #24
- No app/source/test/data/demo asset files changed
- `.claude/settings.local.json` was not staged or committed
- Clean install emitted a pip warning that the exact currently-installed `wandb==0.24.0` candidate is yanked upstream; the install still completed successfully. I kept it pinned to the known current environment version to avoid dependency churn in this PR.
