### PR TITLE
docs: wrap Phase 1 demo hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AI assistant for turning homeowners policies and denial letters into dispute‑focused summaries (A–G structure) for public adjusters and attorneys.
 
-> **Status:** Internal prototype / demo
+> **Status:** Internal prototype / demo, with Phase 1 demo-hardening complete
 >
 > **Frontend:** Streamlit v1 UX (`frontend/app.py`)
 >
@@ -36,12 +36,12 @@ Given:
 
 5. **Renders the results in a Streamlit UI** with:
 
-   - A “New claim” upload flow and progress bar (steps 1–4)
+   - A “New claim” upload flow with research / not-legal-advice framing, step-based progress status, and a compact Recent claims section when local history exists
    - A **Results** screen with:
 
      - Hero summary (plain‑language story + key takeaways)
      - Downloadable Markdown report
-     - Tabs for Dispute summary (A–G), Policy highlights, Denial reasons & angles, and Confidence / debug.
+     - Tabs for Dispute summary (A–G), Policy highlights, Denial reasons & angles, and Confidence.
 
 The goal is to give a **fast triage view** for busy professionals, not to replace full policy / case review.
 
@@ -49,10 +49,11 @@ The goal is to give a **fast triage view** for busy professionals, not to replac
 
 ## Screenshots (v1 UX)
 
-The repo’s GitHub PR and issues contain screenshots of:
+Screenshots were captured separately during Phase 1 and will be curated in a later README polish pass. Issue #15 remains open for inline README screenshots and first-impression polish.
 
-- **New claim flow** – upload policy + denial PDFs, optional nickname and state, step 1–4 progress bar.
+- **New claim flow** – upload policy + denial PDFs, optional nickname and state, step-based status UI.
 - **Results view** – A–G dispute summary, policy highlight checklist, denial reasons & angles, download button.
+- **Confidence view** – confidence score, notes, and verification clauses with raw debug JSON hidden by default.
 
 ---
 
@@ -163,6 +164,8 @@ The bundled demo-safe dispute report lives in:
 
 These tracked files are deterministic demo artifacts, not real client claim data.
 
+For hosted demos, set `DEMO_FORCE_ON=true`. This locks the app to deterministic Demo Mode, disables file uploads and live analysis, and allows the app to boot without `OPENAI_API_KEY`. Keep `DEMO_FORCE_ON=false` for normal local development and the full upload + LLM workflow.
+
 ### New claim flow
 
 1. Go to the **New claim** page (default).
@@ -177,14 +180,16 @@ These tracked files are deterministic demo artifacts, not real client claim data
    - **Denial letter PDF** – corresponding denial for this claim.
 
 4. Click **Analyze claim**.
-5. Watch the bottom status bar as the app walks through:
+5. Watch the status block as the app walks through:
 
-   - Step 1/4 – Analyzing policy PDF
-   - Step 2/4 – Analyzing denial letter
-   - Step 3/4 – Building A–G dispute report
-   - Step 4/4 – Done
+   - Step 1/4: Analyzing policy
+   - Step 2/4: Reading denial letter
+   - Step 3/4: Building dispute analysis
+   - Step 4/4: Preparing outputs
 
 6. When complete, the page scrolls to the **Results** section.
+
+If local claim history exists, the New Claim page also shows up to two **Recent claims** cards. Their **View** actions reuse the existing Claim History detail view and do not expose raw claim text or report JSON.
 
 ### Results view
 
@@ -204,7 +209,9 @@ The results page is split into:
   - **Dispute summary (A–G)** – structured expanders for A–G with inline citations
   - **Policy highlights** – checklist view of helpful provisions vs exclusions
   - **Denial reasons** – bullet list of carrier’s reasons mapped to policy concepts
-  - **Confidence / debug** – meta notes and flags where the model is less confident
+  - **Confidence** – confidence score, notes, and clauses to double-check
+
+Raw A–G JSON and artifact/debug details remain available for developers inside collapsed expanders, but are hidden by default for screenshots and demos.
 
 Under the A–G tab there is an optional **“Full policy breakdown”** section that can show more verbose policy summaries when needed.
 
@@ -259,10 +266,11 @@ This repo is meant for **local experiments**, not production.
 
 Some obvious next steps:
 
+- **README screenshots and first-impression polish** – issue #15 remains open; curate saved screenshots later and add `docs/screenshots/` only if selected screenshots are committed.
+- **Final demo QA** – capture a real Confidence tab screenshot if missing and run one API-backed live analysis before release/demo recording to visually confirm the progress UI.
 - **Better HO3 coverage & carrier diversity** – tune sectioning + prompts across more forms.
 - **State‑aware guidance** – use the `state` field to condition dispute angles.
-- **Multi‑claim workspace** – basic history of recent analyses.
-- ** richer policy / denial upload validation** – catch wrong file types, corrupt PDFs, etc.
+- **Richer policy / denial upload validation** – catch wrong file types, corrupt PDFs, etc.
 - **Export templates** – Word / Docs templates for CRNs, dispute letters, or attorney memos.
 
 If you experiment with the repo and find issues or ideas, feel free to open GitHub Issues or PRs.

--- a/docs/session-wrap-2026-04-25.md
+++ b/docs/session-wrap-2026-04-25.md
@@ -6,9 +6,21 @@
 - PR [#26](https://github.com/itprodirect/policy-dispute-ai-assistant/pull/26) added shared repo agent guidance and the v1.5 demo polish audit/issue plan.
 - PR [#27](https://github.com/itprodirect/policy-dispute-ai-assistant/pull/27) completed issue [#24](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/24): `.env.example` is safe by default and `requirements.txt` pins direct runtime dependencies.
 
+## Completed Phase 1 demo-hardening work
+
+- Issue [#12](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/12): `DEMO_FORCE_ON` hosted demo safety. Hosted demos can be locked to deterministic Demo Mode, uploads/live analysis are disabled, and the app can boot without `OPENAI_API_KEY`.
+- Issue [#13](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/13): New Claim value proposition and research / not-legal-advice framing.
+- Issue [#14](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/14): Confidence tab cleanup. Raw A-G JSON and artifact/debug details are hidden by default behind collapsed developer expanders.
+- Issue [#16](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/16): Live-analysis progress UI now uses a cleaner `st.status`-style step flow.
+- Issue [#17](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/17): New Claim page shows up to two Recent claims when local history exists and reuses the existing Claim History detail view.
+
 ## Current repo state
 
 - Demo Mode works from tracked demo-safe assets and no longer depends on gitignored `data/processed/demo/`.
+- `DEMO_FORCE_ON=true` is the public-demo safety mode: deterministic results render, uploads/live analysis are unavailable, and no OpenAI key is required to boot.
+- `DEMO_FORCE_ON=false` remains the normal local mode with full policy/denial upload workflow and LLM-backed analysis.
+- Results are more screenshot-ready: the hero/value-prop framing is clearer, confidence has its own tab, and raw debug JSON is hidden by default.
+- Claim History behavior remains intact, with a small Recent claims entry point on the New Claim page for existing local runs.
 - `.env.example` defaults to `SAFE_MODE=true` and `PERSIST_RAW_TEXT=false`.
 - `requirements.txt` pins the direct runtime dependencies used by the current working environment.
 - Validation from PR #27:
@@ -16,10 +28,22 @@
   - Clean venv install from `requirements.txt` succeeded.
   - Import checks passed for `streamlit`, `openai`, `pypdf`, `docx`, and `dotenv`.
 
+## Boundaries preserved
+
+- No LLM prompt changes.
+- No report schema changes.
+- No model/API modernization.
+- No auth, billing, user-management, or backend rebuild.
+- This phase was demo hardening, not a product rebuild.
+
 ## Follow-up risk
 
 - `wandb==0.24.0` is pinned to the known working local version, but pip warned that this candidate is yanked upstream. Leave it unchanged in demo/UI work; handle it in a focused dependency cleanup issue or PR.
 
-## Recommended next implementation issue
+## Remaining Phase 1 / portfolio follow-ups
 
-Start with issue [#11](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/11): add tracked sample claim PDFs and a "Try with sample" button. After that, proceed to [#12](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/12) for hosted demo safety.
+- Issue [#15](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/15) remains open for README screenshots and repo first-impression polish. Do not close it from docs-wrap work.
+- Curate the saved screenshots later; add `docs/screenshots/` only if selected screenshots are committed.
+- Capture a real Confidence tab screenshot if one is missing.
+- Before release/demo recording, run one live API-backed analysis with valid PDFs to visually confirm the progress UI.
+- Consider issue [#11](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/11) later if a true live sample-input path is still desired.

--- a/docs/v1-5-demo-polish-audit.md
+++ b/docs/v1-5-demo-polish-audit.md
@@ -1,6 +1,6 @@
 # v1.5 Demo Polish — Audit & Issue Plan
 
-**Status:** Audit + implementation plan. Foundation fixes #10 and #24 are complete; remaining items are implementation follow-ons.
+**Status:** Audit + implementation plan. Foundation fixes #10 and #24 are complete; Phase 1 demo-hardening issues #12, #13, #14, #16, and #17 are complete. Issue #15 remains open for README screenshots and repo first-impression polish.
 **Audience:** Codex 5.5 Pro implementation, plus reviewers converting items into GitHub issues.
 **Goal:** Take the existing internal Streamlit prototype and turn it into something that holds up under a portfolio screenshot, a 60–90 second walkthrough video, and a selective live demo — without rewriting the backend.
 
@@ -11,9 +11,9 @@
 ### 1.1 What works now
 - **End-to-end pipeline is real.** PDF → sectioning → per-section LLM summary → denial-aware A–G report (`src/summarizer_frontier.py`, `src/demo_api.py`).
 - **A–G dispute report is structurally sound.** Pydantic-style dataclasses (`schemas.DisputeReport`) cover all 7 sections, and both Markdown and `.docx` renderers exist (`src/report_builder.py`).
-- **Streamlit v1 UX is fairly complete.** Sidebar nav, intake form, 4-step progress bar, results hero with key takeaways, A–G tabs, downloadable Markdown + Word, claim history page (SQLite at `data/claims.db`).
+- **Streamlit v1 UX is fairly complete.** Sidebar nav, value-prop intake page, `st.status`-style 4-step progress, results hero with key takeaways, A–G tabs, Confidence tab, downloadable Markdown + Word, claim history page, and Recent claims entry point (SQLite at `data/claims.db`).
 - **Citation linking is implemented.** `src/citation_linking.py` matches A–G citations back to raw section text and surfaces "View source" expanders in live runs (`tests/test_citation_linking.py` covers the matching logic).
-- **Demo Mode toggle exists.** Sidebar switch in `frontend/app.py` loads deterministic demo files with zero API calls — the scaffolding is there.
+- **Demo Mode and hosted-demo safety exist.** Sidebar Demo Mode loads deterministic demo files with zero API calls; `DEMO_FORCE_ON=true` locks hosted demos to that path, disables uploads/live analysis, and boots without `OPENAI_API_KEY`.
 - **Privacy hygiene is present.** `SAFE_MODE` and `PERSIST_RAW_TEXT` flags in `src/config.py` route outputs to `data/processed_safe/` and strip raw text before returning to the UI.
 - **Telemetry hooks are wired.** Optional W&B logging via `src/wandb_telemetry.py` (claim-level rollups, A–G presence metrics) — useful but off by default.
 - **Disclaimers are present** in three places (intake page markdown, results page caption, rendered Markdown/Word reports) — framing is not legal advice.
@@ -30,20 +30,22 @@
 - 🔴 **No sample input PDFs are tracked.** `data/raw_policies/` and `data/raw_denials/` are gitignored. A first-time visitor cannot do a real "upload and run" demo without bringing their own PDFs.
 - ✅ **`.env.example` is now safe by default.** PR [#27](https://github.com/itprodirect/policy-dispute-ai-assistant/pull/27) changed `PERSIST_RAW_TEXT=false` and documented that `SAFE_MODE=true` strips raw text even if persistence is changed.
 - ✅ **`requirements.txt` now pins direct runtime dependencies.** PR [#27](https://github.com/itprodirect/policy-dispute-ai-assistant/pull/27) added exact pins for the working local versions.
-- 🟡 **Page title is wordy:** *"Policy Dispute AI – Claim A–G Demo"*. The hero immediately repeats the same string.
-- 🟡 **No "30-second understanding" hero.** First-time visitors land on a generic upload form. There's no value-prop card, no example claim, no walkthrough teaser.
-- 🟡 **Confidence/debug tab dumps raw JSON.** Useful for dev, ugly for screenshots — raw `dispute_report` JSON is the default rendering for tab #4.
+- ✅ **Hosted demo safety is in place.** `DEMO_FORCE_ON=true` locks the app to deterministic Demo Mode, disables uploads/live analysis, and no longer requires `OPENAI_API_KEY`.
+- ✅ **New Claim has a 30-second value proposition.** The page now frames what the tool does, who it is for, and what it is not, with research-prototype / not-legal-advice framing.
+- ✅ **Confidence/debug no longer dumps raw JSON by default.** The tab is now **Confidence**, with raw A-G JSON and artifact details behind collapsed developer expanders.
+- ✅ **Live-analysis progress is cleaner.** The live workflow uses a single `st.status`-style block with explicit Step 1/4 through Step 4/4 labels.
+- ✅ **Recent claims entry point exists.** The New Claim page shows up to two Recent claims when local history exists and reuses the existing Claim History detail view.
 - 🟡 **Hero takeaways are weak.** The "Key takeaways" picker just grabs the first 3 items from coverage_highlights, then dispute_angles. No prioritization, no insurer-name display, no claim-context summary.
-- 🟡 **Demo Mode UI is buried.** It's a sidebar toggle with a generic `st.info` banner. For a portfolio viewer who lands on the page, "click here to see the demo" should be the dominant CTA.
 - 🟡 **No README screenshots.** README references screenshots "in the GitHub PR and issues" but the repo itself has zero embedded images. The GitHub repo card is text-only.
 - 🟡 **`frontend/data/processed/`** exists as a stale duplicate (gitignored, but leftover from a prior `cwd` issue). Small code-hygiene smell.
 - 🟡 **No CI / no badges.** No GitHub Actions; tests aren't being verified on push.
 
 ### 1.4 What's missing for a smooth live demo
 - A *one-click* "Try this with the bundled sample claim" path that uses real PDFs already in the repo.
-- A `DEMO_FORCE_ON` env so a hosted demo can disable the Live Mode/upload path entirely (no API key needed, no abuse risk).
-- Deterministic, *real* dispute artifacts in the demo bundle (full A–G with denial reasons populated).
-- A short walkthrough script + screenshot recipe so re-shoots are deterministic.
+- README screenshots and first-impression polish (#15 remains open).
+- Curated screenshot assets; add `docs/screenshots/` later only if selected screenshots are committed.
+- A real Confidence tab screenshot if the saved capture set does not already include one.
+- One live API-backed analysis run before release/demo recording to visually confirm the progress UI.
 
 ### 1.5 Architectural notes (not problems, just context)
 - The pipeline is OpenAI-only via `chat.completions` with `response_format=json_object` (`src/llm_client.py`). Fine for v1.5; no change needed.
@@ -184,7 +186,7 @@ python -c "import streamlit, openai, pypdf, docx, dotenv; print('OK')"
 
 ### P1 — High-leverage UX & screenshot polish
 
-#### Issue P1-1 — Add `DEMO_FORCE_ON` env flag for hosted demos ([#12](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/12))
+#### Issue P1-1 — Add `DEMO_FORCE_ON` env flag for hosted demos ([#12](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/12)) — Completed
 
 **Priority:** P1
 **Type:** code
@@ -217,7 +219,7 @@ DEMO_FORCE_ON=true streamlit run frontend/app.py
 
 ---
 
-#### Issue P1-2 — Hero polish + 30-second value prop ([#13](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/13))
+#### Issue P1-2 — Hero polish + 30-second value prop ([#13](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/13)) — Completed
 
 **Priority:** P1
 **Type:** design + code
@@ -244,13 +246,13 @@ DEMO_FORCE_ON=true streamlit run frontend/app.py
 
 ---
 
-#### Issue P1-3 — Clean up Confidence / Debug tab ([#14](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/14))
+#### Issue P1-3 — Clean up Confidence / Debug tab ([#14](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/14)) — Completed
 
 **Priority:** P1
 **Type:** code
 **Codex-safe:** ✅ yes
 
-**Why it matters:** Tab #4 (`Confidence / debug`) currently dumps raw `dispute_report` JSON. That's a debug surface, not a screenshot surface. Confidence/G content is currently buried inside the A–G tab's expander.
+**Why it mattered:** Tab #4 (`Confidence / debug`) previously dumped raw `dispute_report` JSON. The completed cleanup made the tab screenshot-ready while keeping raw A-G JSON available in collapsed developer expanders.
 
 **Scope:**
 - Rename the tab to **"Confidence"** (drop "/ debug").
@@ -301,7 +303,7 @@ DEMO_FORCE_ON=true streamlit run frontend/app.py
 
 ---
 
-#### Issue P1-5 — Tighten progress UI and step labels ([#16](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/16))
+#### Issue P1-5 — Tighten progress UI and step labels ([#16](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/16)) — Completed
 
 **Priority:** P1
 **Type:** code
@@ -326,7 +328,7 @@ DEMO_FORCE_ON=true streamlit run frontend/app.py
 
 ---
 
-#### Issue P1-6 — Add "Recent runs" sample card on intake page ([#17](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/17))
+#### Issue P1-6 — Add "Recent runs" sample card on intake page ([#17](https://github.com/itprodirect/policy-dispute-ai-assistant/issues/17)) — Completed
 
 **Priority:** P1
 **Type:** code (small)
@@ -497,18 +499,20 @@ Foundation completed:
 
 1. ✅ **P0-1** Track demo assets + ship real dispute bundle. Completed in PR [#25](https://github.com/itprodirect/policy-dispute-ai-assistant/pull/25).
 2. ✅ **P0-3** Fix `.env.example` + pin `requirements.txt`. Completed in PR [#27](https://github.com/itprodirect/policy-dispute-ai-assistant/pull/27).
+3. ✅ **#12 / P1-1** Add `DEMO_FORCE_ON` for hosted demo safety.
+4. ✅ **#13 / P1-2** Polish hero and 30-second value proposition.
+5. ✅ **#14 / P1-3** Clean up Confidence tab/debug JSON.
+6. ✅ **#16 / P1-5** Tighten analysis progress UI.
+7. ✅ **#17 / P1-6** Add Recent claims card.
 
-Next recommended implementation sequence from the current `main` branch:
+Next recommended follow-up sequence from the current `main` branch:
 
-1. **#11 / P0-2** Add tracked sample claim PDFs and "Try with sample" button.
-2. **#12 / P1-1** Add `DEMO_FORCE_ON` for hosted demo safety.
-3. **#13 / P1-2** Polish hero and 30-second value proposition.
-4. **#14 / P1-3** Clean up Confidence tab/debug JSON.
-5. **#16 / P1-5** Tighten analysis progress UI.
-6. **#18 / P2-1** Prepare Streamlit Community Cloud deployment.
-7. **#20 / P2-3** Add screenshot/video walkthrough recipe.
+1. **#15 / P1-4** README screenshots and repo first-impression polish. Screenshots were captured separately and should be curated before committing any assets.
+2. **#18 / P2-1** Prepare Streamlit Community Cloud deployment.
+3. **#20 / P2-3** Add screenshot/video walkthrough recipe.
+4. **#11 / P0-2** Add tracked sample claim PDFs and "Try with sample" button, if a true live sample-input path is still desired.
 
-Keep #11 first unless hosting becomes the immediate priority; the sample path is the next blocker for a compelling live walkthrough.
+Do not close #15 until README screenshots are actually selected, committed, and rendered correctly on GitHub.
 
 ---
 
@@ -518,14 +522,14 @@ Keep #11 first unless hosting becomes the immediate priority; the sample path is
 - [ ] Run with the polished UI (after P1-2/3/5).
 - [ ] Browser at **1440 × 900** (good GitHub README aspect ratio) or **1920 × 1080** for video.
 - [ ] Streamlit "wide" layout enabled (already is — `st.set_page_config(layout="wide")`).
-- [ ] Use the bundled sample claim (P0-2) so output is deterministic.
+- [ ] Use deterministic Demo Mode for zero-API screenshots, or run one live API-backed analysis with valid local PDFs when capturing the progress UI.
 - [ ] Light theme — don't ship a dark-mode screenshot if README is light.
 - [ ] Hide the browser bookmarks bar; hide any extension icons that contain personal info.
-- [ ] Empty `data/claims.db` so Claim History page shows the "Recent claims" example, not a developer's accumulated test runs.
+- [ ] Use a clean/sanitized `data/claims.db` for Claim History / Recent claims shots; do not show a developer's accumulated test runs.
 
 ### 5.2 Required shots
 1. **Landing / intake**: hero with value prop card, "Try with sample" button visible.
-2. **Mid-analysis**: `st.status` block with Step 3/4 highlighted (live capture during a real run).
+2. **Mid-analysis**: `st.status` block with Step 3/4 highlighted (live capture during a real API-backed run).
 3. **Results hero**: confidence metric visible, plain-language overview, key takeaways, both download buttons.
 4. **A–G dispute tab**: section B and C expanded, citation accordions visible.
 5. **Citation expander expanded**: showing real policy section text under "View source".
@@ -535,7 +539,7 @@ Keep #11 first unless hosting becomes the immediate priority; the sample path is
 
 ### 5.3 Walkthrough video (60–90s)
 - 0–10s: README/landing → "Try with sample" click.
-- 10–30s: progress bar runs (live), Results hero appears.
+- 10–30s: `st.status` progress flow runs (live), Results hero appears.
 - 30–55s: scroll through A–G tabs, click a "View source" accordion.
 - 55–75s: hit "Download as Word", open the file, scroll once.
 - 75–90s: cut back to README, point at the disclaimer + GitHub link.
@@ -567,22 +571,22 @@ Keep #11 first unless hosting becomes the immediate priority; the sample path is
 
 ---
 
-## 7. Recommended next implementation PRs
+## 7. Recommended next PRs
 
-### Recommended next implementation PR — **#11 / P0-2: Sample PDFs + "Try with sample" button**
+### Recommended next PR — **#15 / P1-4: README screenshots + first-impression polish**
 
-**Why next:** Demo Mode and dependency reproducibility are now fixed. The next bottleneck is "I can't actually try the live pipeline without bringing my own PDFs." Solving that turns every README visitor into a potential live-demo user and gives the walkthrough video something real to film.
+**Why next:** The Phase 1 code hardening is complete, but the GitHub repo still needs curated screenshots to show the polished New Claim page, Results hero, A-G structure, and clean Confidence tab. Screenshots were captured separately; this follow-up should select, sanitize, and wire them into the README.
 
 **Concrete first steps for the implementer:**
-1. Confirm candidate sample inputs contain no real client data or PII.
-2. Add tracked sample assets under `assets/samples/`.
-3. Add the "Try with sample claim" button on the New Claim page.
-4. Run the same code path as a normal upload.
-5. Keep the UI copy clear that the sample is synthetic/regulator-filed and not legal advice.
+1. Review the saved screenshot set and discard anything with personal data, noisy browser chrome, raw JSON, or stale UI.
+2. Capture a real Confidence tab screenshot if it is missing.
+3. Add `docs/screenshots/` only if selected screenshots are being committed.
+4. Update `README.md` with inline images and concise first-impression copy.
+5. Before final release/demo recording, run one live API-backed analysis with valid PDFs to visually confirm the progress UI.
 
-### Recommended follow-up implementation PR — **#12 / P1-1: `DEMO_FORCE_ON` hosted demo safety**
+### Optional later PR — **#11 / P0-2: Sample PDFs + "Try with sample" button**
 
-**Why second:** Once the sample path exists, `DEMO_FORCE_ON` makes the hosted demo safe by disabling uploads and API calls on public infrastructure.
+**Why later:** Local mode still supports full uploads, and hosted demos are safe through `DEMO_FORCE_ON`. A tracked sample-input path would make live pipeline demos easier, but it requires careful sample document curation and is separate from the Phase 1 hardening wrap.
 
 ---
 
@@ -591,6 +595,7 @@ Keep #11 first unless hosting becomes the immediate priority; the sample path is
 - ❌ **Do NOT add user authentication.** This is a portfolio demo; auth is overkill, makes hosting harder, and signals "trying too hard."
 - ❌ **Do NOT introduce a server-side database** (Postgres, Supabase, etc.). The existing SQLite is fine for the demo workflow.
 - ❌ **Do NOT rewrite the frontend in Next.js / React.** The Streamlit frontend works, the value is in the A–G logic, and a rewrite is a multi-week distraction with no portfolio upside.
+- ❌ **Do NOT treat Phase 1 as model/API modernization.** No LLM prompt changes, report schema changes, Responses/API migration, or backend architecture rebuild were part of the demo-hardening pass.
 - ❌ **Do NOT add new policy form support** (HO5, HO6, commercial forms). v1.5 is polish, not coverage expansion.
 - ❌ **Do NOT add legal-advice claims, attorney listings, jurisdiction matchmaking, or "guaranteed outcomes" copy.** The "not legal advice" framing must stay front and center.
 - ❌ **Do NOT commit any real client documents**, even sanitized ones. Use regulator-filed forms (HO3 ISO, USAA OPIC, TRUE FL) and synthetic denials only.


### PR DESCRIPTION
## Summary
- Update README to reflect the current Phase 1 demo-hardening state: DEMO_FORCE_ON safety, value-prop framing, Confidence tab cleanup, step-based progress UI, and Recent claims.
- Update the 2026-04-25 session wrap with completed Phase 1 work, preserved boundaries, and remaining portfolio follow-ups.
- Refresh the v1.5 demo polish audit so completed #12, #13, #14, #16, and #17 are marked complete and #15 remains the next screenshot/README polish follow-up.

This docs pass follows completed #12, #13, #14, #16, and #17.

References #15. Does not close #15.

## Validation
- git diff --check
- git diff --name-only confirmed docs-only changes: README.md, docs/session-wrap-2026-04-25.md, docs/v1-5-demo-polish-audit.md
- Confirmed no docs/screenshots/ directory was created

## Notes
- No screenshots were added or moved.
- No app code, tests, dependencies, prompts, report schema, model/API behavior, auth, or backend architecture changes were made.