### PR TITLE
docs: clarify phase roadmap before model refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ This repo is meant for **local experiments**, not production.
 
 ## Roadmap / ideas
 
-Phase 1 demo hardening is complete. Current Phase 2 sequencing lives in `docs/03-roadmap.md`; the next planned issue is GitHub Actions CI for pytest.
+Phase 1A demo polish is complete. The next phase is Phase 1B operational closeout, starting with GitHub Actions CI for pytest. Full sequencing for Phase 1B, Phase 1C, and Phase 2 lives in `docs/03-roadmap.md`.
 
 If you experiment with the repo and find issues or ideas, feel free to open GitHub Issues or PRs.
 

--- a/docs/01-current-state.md
+++ b/docs/01-current-state.md
@@ -2,9 +2,9 @@
 
 Last updated: 2026-04-25
 
-Phase 1 demo hardening is complete. The app remains a Streamlit research prototype with deterministic Demo Mode, a live API-backed local workflow, README screenshots, and explicit AI-generated / not-legal-advice framing.
+Phase 1A demo polish is complete. The app remains a Streamlit research prototype with deterministic Demo Mode, a live API-backed local workflow, README screenshots, and explicit AI-generated / not-legal-advice framing.
 
-## Completed Phase 1 Issues
+## Completed Phase 1A Issues
 
 - #12 `DEMO_FORCE_ON` hosted demo safety.
 - #13 Hero/value proposition and research framing.
@@ -20,7 +20,11 @@ Phase 1 demo hardening is complete. The app remains a Streamlit research prototy
 
 ## Not Started
 
-Phase 2 has not started yet. No CI, deployment config, citation accordion update, export polish, model/API modernization, prompt changes, schema changes, backend rebuild, auth, users, billing, or storage changes have been started for Phase 2.
+Phase 1B and 1C have not started yet. Phase 2 model/speed refactor has not started either.
+
+Phase 1B covers operational closeout: CI, stale artifact cleanup, and the walkthrough/screenshot recipe. Phase 1C covers hosted demo and trust polish: deployment prep, Demo Mode citation/source accordions, and export context polish. True Phase 2 work is the model/API/speed refactor and remains deferred.
+
+No CI, deployment config, citation accordion update, export polish, model/API modernization, prompt changes, schema changes, backend rebuild, auth, users, billing, or storage changes have been started.
 
 ## Local Cleanup
 

--- a/docs/03-roadmap.md
+++ b/docs/03-roadmap.md
@@ -1,10 +1,6 @@
 # Roadmap
 
-## Phase 1
-
-Phase 1 demo hardening is complete.
-
-Completed issues:
+## Phase 1A: Demo polish — completed
 
 - #12 `DEMO_FORCE_ON` hosted demo safety.
 - #13 Hero/value proposition.
@@ -13,24 +9,47 @@ Completed issues:
 - #16 Progress UI and step labels.
 - #17 Recent claims card.
 
-## Phase 2 Order
+## Phase 1B: Operational closeout — next
 
-Work Phase 2 in this order, one issue per PR:
+Work one issue per PR, in this order:
 
-1. #19 Add GitHub Actions CI for pytest.
-2. #18 Prepare Streamlit Community Cloud deployment.
-3. #21 Enable citation/source accordions in Demo Mode.
-4. #20 Add walkthrough video and screenshot recipe.
-5. #22 Document cleanup for stale frontend/data artifacts.
-6. #23 Add human-readable context to dispute report exports.
-7. Model/API/speed inspection only after the above unless a blocker appears.
+1. #19 GitHub Actions CI for pytest.
+2. #22 Clean up stale `frontend/data/` artifacts.
+3. #20 Walkthrough video and screenshot recipe.
 
-## Do Not Start Phase 2 With
+Note:
+The walkthrough/video recipe can be deferred from the current coding session if needed, but it remains part of Phase 1B closeout.
 
-- Responses API migration.
-- Structured Outputs.
-- Model swapping.
-- Prompt changes.
+## Phase 1C: Hosted demo and trust polish
+
+Work one issue per PR, in this order:
+
+1. #18 Streamlit Community Cloud deployment prep.
+2. #21 Citation/source accordions in Demo Mode.
+3. #23 Human-readable context in dispute report exports.
+
+Note:
+Deployment prep may come before citation accordions, but the hosted demo should not be publicly promoted as a final portfolio demo until the Demo Mode citation/source accordion work is complete.
+
+## Phase 2: Model and speed refactor — not started
+
+Begin only after Phase 1A, 1B, and 1C are complete or intentionally deferred, and only after focused inspection or measurement.
+
+Scope:
+
+- Replace the Chat Completions wrapper with the Responses API.
+- Add Structured Outputs schemas for sectioning and dispute report generation.
+- Add stage-specific model configuration.
+- Parallelize or reduce per-section LLM calls.
+- Add a focused-analysis mode that targets the most material sections.
+- Remove redundant PDF reprocessing in the live pipeline.
+- Add a benchmark report comparing latency, cost, and report quality before and after.
+
+## Out of scope across all phases
+
+- Prompt rewrites that change A-G semantics.
 - Report schema changes.
 - Backend rebuild.
-- Auth or user management.
+- Auth, users, billing, or server-side storage.
+- New policy form support such as HO5, HO6, or commercial.
+- Real client data, fake testimonials, or implied production outcomes.

--- a/docs/04-agent-workflow.md
+++ b/docs/04-agent-workflow.md
@@ -6,7 +6,7 @@ Use this workflow for Codex, Claude Code, and future agent sessions.
 
 - Pick one GitHub issue or one tightly scoped docs task.
 - Keep each branch and PR focused on that single concern.
-- Do not bundle Phase 2 work into docs cleanup, CI, deployment, prompt, schema, or model/API changes.
+- Do not bundle work across phases. Do not mix Phase 2 model/API refactor work into Phase 1B or Phase 1C PRs.
 
 ## Inspect Before Editing
 

--- a/docs/05-decision-log.md
+++ b/docs/05-decision-log.md
@@ -10,14 +10,14 @@ The app stays framed as an educational research prototype. It is not a legal pro
 
 Hosted demos should use `DEMO_FORCE_ON=true` so uploads and live API-backed analysis are disabled and deterministic demo-safe artifacts are used.
 
-### Finish README screenshots before Phase 2
+### Finish README screenshots before Phase 1B
 
-README screenshots and first-impression polish were completed before starting Phase 2 so visitors see the current v1 UX without relying on stale issue notes.
+README screenshots and first-impression polish were completed before Phase 1B operational closeout so visitors see the current v1 UX without relying on stale issue notes.
 
-### Add CI before deeper behavior work
+### Begin Phase 1B with CI
 
-Phase 2 should begin with #19 GitHub Actions CI for pytest before deployment prep or deeper app behavior changes.
+Phase 1B should begin with #19 GitHub Actions CI for pytest before stale artifact cleanup or walkthrough recipe work.
 
-### Defer model/API modernization
+### Defer model/API modernization to Phase 2
 
-Responses API migration, Structured Outputs, model swapping, prompt changes, and report schema changes are deferred until after Phase 2 setup work and only after focused inspection or measurement.
+Responses API migration, Structured Outputs, stage-specific model configuration, and speed/pipeline work are true Phase 2 model/speed refactor items. They are deferred until after Phase 1B and Phase 1C are complete or intentionally deferred, and only after focused inspection or measurement.

--- a/docs/06-heartbeat.md
+++ b/docs/06-heartbeat.md
@@ -4,16 +4,19 @@ Date: 2026-04-25
 
 ## Status
 
-- Phase 1 demo hardening is complete.
+- Phase 1A demo polish is complete.
 - PR #34 and PR #35 are merged.
 - Issue #15 is closed.
-- Phase 2 has not started yet.
-- The next issue is #19: add GitHub Actions CI for pytest.
+- Phase 1B operational closeout has not started.
+- Phase 1C hosted demo and trust polish has not started.
+- Phase 2 model/speed refactor has not started.
+- The next build issue is #19: add GitHub Actions CI for pytest.
 
 ## Current Watchouts
 
-- Keep Phase 2 ordered. Start with CI, then deployment prep.
-- Do not start model/API modernization before inspection and measurement.
+- Keep phase boundaries clear. Start Phase 1B with CI, then stale artifact cleanup and walkthrough recipe work.
+- Do not mix Phase 2 model/API refactor work into Phase 1B or Phase 1C PRs.
+- Do not start model/API modernization before Phase 1B/1C completion or intentional deferral, inspection, and measurement.
 - Do not change prompts or report schemas as part of docs, CI, or deployment work.
 - Keep public-demo safety centered on deterministic Demo Mode and `DEMO_FORCE_ON`.
 - Do not commit local runtime artifacts, real claim data, secrets, or screenshot candidates.

--- a/docs/08-memory.md
+++ b/docs/08-memory.md
@@ -4,13 +4,16 @@ Durable context for future Codex and Claude sessions.
 
 - Repo: `policy-dispute-ai-assistant`.
 - Current branch baseline: `main`.
-- Phase 1 is complete.
-- Phase 2 has not started.
-- Next issue: #19 Add GitHub Actions CI for pytest.
+- Phase 1A demo polish is complete.
+- Phase 1B operational closeout has not started.
+- Phase 1C hosted demo and trust polish has not started.
+- Phase 2 model/speed refactor has not started.
+- Next issue: #19 Add GitHub Actions CI for pytest, the first Phase 1B issue.
 - Recent merged PRs: #34 docs wrap, #35 README screenshot polish.
 - Final README screenshots live in `docs/screenshots/` and should remain unchanged unless a focused screenshot task requires it.
 - Local screenshot candidates were moved outside the repo to `C:\Users\user\Desktop\policy-dispute-screenshot-candidates-archive\`.
 - Preserve research prototype, AI-generated, not-legal-advice, and demo-safe framing.
 - Keep work one issue per PR.
-- Do not begin Phase 2 with model/API migration, Structured Outputs, model swaps, prompt changes, schema changes, backend rebuild, auth, users, billing, or storage.
+- Phase 2 means the model/speed refactor: Responses API, Structured Outputs, stage-specific model configuration, speed/pipeline work, and benchmarking.
+- Prompt rewrites, report schema changes, backend rebuild, auth, users, billing, and storage are out of scope across all phases unless a future explicit issue changes that boundary.
 - Do not commit secrets, real client data, real claim names, claim numbers, or fake client proof.


### PR DESCRIPTION
## Summary
- Recalibrates the roadmap language from broad Phase 2 wording into Phase 1A, Phase 1B, Phase 1C, and true Phase 2.
- Defines Phase 1A demo polish as complete.
- Defines Phase 1B operational closeout as #19 CI, #22 stale `frontend/data/` cleanup, and #20 walkthrough/screenshot recipe.
- Defines Phase 1C hosted demo and trust polish as #18 deployment prep, #21 Demo Mode citation/source accordions, and #23 export context polish.
- Reserves true Phase 2 for model/speed/API refactor work.

## Context
PR #36 merged before this follow-up roadmap correction could be included. This PR reapplies that docs-only correction from a fresh branch based on latest `main`.

## Scope confirmation
- Docs-only PR.
- Phase 1B starts with #19 GitHub Actions CI for pytest.
- True Phase 2 is reserved for model/speed/API refactor work: Responses API, Structured Outputs, stage-specific model config, speed/pipeline work, and benchmarking.
- No app code, CI, deployment config, prompt, schema, model/API behavior, backend architecture, screenshot, or archived-doc files were changed.