### PR TITLE
ci: add pytest GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install pytest
+
+      - name: Run tests
+        run: python -m pytest -q

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Policy Dispute AI Assistant
 
+[![CI](https://github.com/itprodirect/policy-dispute-ai-assistant/actions/workflows/ci.yml/badge.svg)](https://github.com/itprodirect/policy-dispute-ai-assistant/actions/workflows/ci.yml)
+
 AI assistant for turning homeowners policies and denial letters into dispute‑focused summaries (A–G structure) for public adjusters and attorneys.
 
 > **Status:** Internal prototype / demo, with Phase 1 demo-hardening complete


### PR DESCRIPTION
Closes #19

Summary:
- Added `.github/workflows/ci.yml` to run pytest in GitHub Actions on pull requests and pushes to `main`.
- The workflow checks out the repo, sets up Python, installs `requirements.txt`, installs `pytest`, and runs `python -m pytest -q`.
- Added a README CI badge for the finalized workflow path.

Python version used:
- 3.11

Test command used:
- `python -m pytest -q`

Local pytest result:
- `20 passed in 0.61s`
- Pre-change result was `20 passed in 0.46s`.

README badge:
- Added.

Scope confirmation:
- No app behavior, deployment, model/API, prompt, schema, backend, screenshot, or archived docs changes were made.