### PR TITLE
docs: clarify runtime artifacts and stale data paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,4 @@ Thumbs.db
 # -------------------------
 data/uploads/
 data/claims.db
-frontend/data/
 wandb/

--- a/README.md
+++ b/README.md
@@ -110,8 +110,12 @@ policy-dispute-ai-assistant/
 │  └─ app_v0_minimul.py      # Original single-page prototype (kept for reference)
 │
 ├─ data/
+│  ├─ raw_policies/          # Local policy PDFs for CLI runs (gitignored)
+│  ├─ raw_denials/           # Local denial inputs for CLI runs (gitignored)
+│  ├─ uploads/               # Streamlit upload cache (gitignored)
 │  ├─ processed/             # Local generated JSON + Markdown outputs (gitignored)
-│  └─ uploads/               # Local upload cache (gitignored)
+│  ├─ processed_safe/        # SAFE_MODE generated outputs (gitignored)
+│  └─ claims.db              # Local claim history SQLite DB (gitignored)
 │
 ├─ docs/                     # Durable project docs, screenshots, and archived notes
 ├─ notebooks/                # Experimental notebooks / scratchpads

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -62,6 +62,19 @@ Do not rebuild this bundle from real client claim data.
 
 ---
 
+## Local Runtime Artifacts
+
+The canonical local artifact location is the repository-root `data/` directory:
+
+- `data/uploads/` for Streamlit upload cache files
+- `data/processed/` for normal generated summaries and reports
+- `data/processed_safe/` for `SAFE_MODE=true` generated outputs
+- `data/claims.db` for local claim history
+
+`frontend/data/` is a stale artifact path from earlier local runs. It is not read by the current app or backend and can be removed if it appears.
+
+---
+
 ## Troubleshooting
 
 ### Streamlit boots but errors when demo mode is on

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -40,7 +40,10 @@ The UI renders this structure in tabs and offers Markdown and Word downloads. Al
 
 ## Local Artifacts
 
+Root `data/` is the canonical local runtime artifact location.
+
 - `data/uploads/` holds local upload cache files.
 - `data/processed/` and `data/processed_safe/` hold local generated outputs.
 - `data/claims.db` stores local claim history.
+- `frontend/data/` is not used by the current app or backend; if present, it is a stale local artifact from older runs.
 - Runtime artifacts and real client data should not be committed.


### PR DESCRIPTION
Closes #22

Summary:
- Removed the stale local `frontend/data/` artifact directory from this workspace after confirming it is ignored and untracked.
- Removed the obsolete `frontend/data/` ignore entry so future accidental recreations are visible in git status.
- Clarified root `data/` runtime artifact paths in `README.md`, `RUNBOOK.md`, and `docs/02-architecture.md`.

Current canonical runtime artifact location:
- Repository-root `data/`
- `data/uploads/` for Streamlit upload cache files
- `data/processed/` for normal generated summaries and reports
- `data/processed_safe/` for SAFE_MODE outputs
- `data/claims.db` for local claim history

Test result:
- `python -m pytest -q` -> `20 passed in 0.36s`

Scope confirmation:
- No app behavior, deployment, model/API, prompt, schema, or backend changes were made.