### PR TITLE
docs: defer walkthrough recipe and start Phase 1C

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ This repo is meant for **local experiments**, not production.
 
 ## Roadmap / ideas
 
-Phase 1A demo polish is complete. The next phase is Phase 1B operational closeout, starting with GitHub Actions CI for pytest. Full sequencing for Phase 1B, Phase 1C, and Phase 2 lives in `docs/03-roadmap.md`.
+Phase 1A demo polish and Phase 1B technical closeout are complete. #20 walkthrough video and screenshot recipe remains open, but is intentionally deferred to a future brand/content walkthrough session. Phase 1C may begin with #18 Streamlit Community Cloud deployment prep. True Phase 2 remains reserved for model/speed/API refactor work. Full sequencing lives in `docs/03-roadmap.md`.
 
 If you experiment with the repo and find issues or ideas, feel free to open GitHub Issues or PRs.
 

--- a/docs/01-current-state.md
+++ b/docs/01-current-state.md
@@ -17,14 +17,18 @@ Phase 1A demo polish is complete. The app remains a Streamlit research prototype
 
 - PR #34: docs wrap for Phase 1 status and boundaries.
 - PR #35: README screenshot polish with five committed demo-safe screenshots.
+- PR #38: GitHub Actions CI for pytest.
+- PR #39: stale `frontend/data/` artifact cleanup and runtime artifact docs.
 
-## Not Started
+## Current Phase
 
-Phase 1B and 1C have not started yet. Phase 2 model/speed refactor has not started either.
+Phase 1B technical closeout is complete with #19 GitHub Actions CI for pytest and #22 stale `frontend/data/` artifact cleanup.
 
-Phase 1B covers operational closeout: CI, stale artifact cleanup, and the walkthrough/screenshot recipe. Phase 1C covers hosted demo and trust polish: deployment prep, Demo Mode citation/source accordions, and export context polish. True Phase 2 work is the model/API/speed refactor and remains deferred.
+#20 walkthrough video and screenshot recipe remains open, but it is intentionally deferred to a future brand/content walkthrough session.
 
-No CI, deployment config, citation accordion update, export polish, model/API modernization, prompt changes, schema changes, backend rebuild, auth, users, billing, or storage changes have been started.
+Phase 1C technical work may begin with #18 Streamlit Community Cloud deployment prep. Phase 1C also includes #21 Demo Mode citation/source accordions and #23 export context polish.
+
+True Phase 2 remains reserved for model/speed/API refactor work. No deployment config, citation accordion update, export polish, model/API modernization, prompt changes, schema changes, backend rebuild, auth, users, billing, or storage changes have been started.
 
 ## Local Cleanup
 

--- a/docs/03-roadmap.md
+++ b/docs/03-roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Phase 1A: Demo polish — completed
+## Phase 1A: Demo polish - completed
 
 - #12 `DEMO_FORCE_ON` hosted demo safety.
 - #13 Hero/value proposition.
@@ -9,18 +9,17 @@
 - #16 Progress UI and step labels.
 - #17 Recent claims card.
 
-## Phase 1B: Operational closeout — next
+## Phase 1B: Operational closeout - technical closeout complete
 
-Work one issue per PR, in this order:
+Completed:
 
-1. #19 GitHub Actions CI for pytest.
-2. #22 Clean up stale `frontend/data/` artifacts.
-3. #20 Walkthrough video and screenshot recipe.
+- #19 GitHub Actions CI for pytest.
+- #22 Clean up stale `frontend/data/` artifacts.
 
 Note:
-The walkthrough/video recipe can be deferred from the current coding session if needed, but it remains part of Phase 1B closeout.
+#20 walkthrough video and screenshot recipe remains open, but it is intentionally deferred to a future brand/content walkthrough session. Do not mix it into technical hardening sessions.
 
-## Phase 1C: Hosted demo and trust polish
+## Phase 1C: Hosted demo and trust polish - next
 
 Work one issue per PR, in this order:
 
@@ -31,9 +30,9 @@ Work one issue per PR, in this order:
 Note:
 Deployment prep may come before citation accordions, but the hosted demo should not be publicly promoted as a final portfolio demo until the Demo Mode citation/source accordion work is complete.
 
-## Phase 2: Model and speed refactor — not started
+## Phase 2: Model and speed refactor - not started
 
-Begin only after Phase 1A, 1B, and 1C are complete or intentionally deferred, and only after focused inspection or measurement.
+True Phase 2 remains reserved for model/speed/API refactor work. Begin only after Phase 1A, 1B, and 1C are complete or intentionally deferred, and only after focused inspection or measurement.
 
 Scope:
 

--- a/docs/06-heartbeat.md
+++ b/docs/06-heartbeat.md
@@ -5,16 +5,16 @@ Date: 2026-04-25
 ## Status
 
 - Phase 1A demo polish is complete.
-- PR #34 and PR #35 are merged.
-- Issue #15 is closed.
-- Phase 1B operational closeout has not started.
+- Phase 1B technical closeout is complete with #19 GitHub Actions CI for pytest and #22 stale `frontend/data/` artifact cleanup.
+- #20 walkthrough video and screenshot recipe remains open but is intentionally deferred to a future brand/content walkthrough session.
 - Phase 1C hosted demo and trust polish has not started.
 - Phase 2 model/speed refactor has not started.
-- The next build issue is #19: add GitHub Actions CI for pytest.
+- The next technical issue is #18: Streamlit Community Cloud deployment prep.
 
 ## Current Watchouts
 
-- Keep phase boundaries clear. Start Phase 1B with CI, then stale artifact cleanup and walkthrough recipe work.
+- Keep phase boundaries clear. Phase 1C may begin with #18 Streamlit Community Cloud deployment prep.
+- Do not start #20 during technical hardening; defer it to a future brand/content walkthrough session.
 - Do not mix Phase 2 model/API refactor work into Phase 1B or Phase 1C PRs.
 - Do not start model/API modernization before Phase 1B/1C completion or intentional deferral, inspection, and measurement.
 - Do not change prompts or report schemas as part of docs, CI, or deployment work.

--- a/docs/08-memory.md
+++ b/docs/08-memory.md
@@ -5,15 +5,16 @@ Durable context for future Codex and Claude sessions.
 - Repo: `policy-dispute-ai-assistant`.
 - Current branch baseline: `main`.
 - Phase 1A demo polish is complete.
-- Phase 1B operational closeout has not started.
+- Phase 1B technical closeout is complete with #19 GitHub Actions CI for pytest and #22 stale `frontend/data/` artifact cleanup.
+- #20 walkthrough video and screenshot recipe remains open but is intentionally deferred to a future brand/content walkthrough session.
 - Phase 1C hosted demo and trust polish has not started.
 - Phase 2 model/speed refactor has not started.
-- Next issue: #19 Add GitHub Actions CI for pytest, the first Phase 1B issue.
-- Recent merged PRs: #34 docs wrap, #35 README screenshot polish.
+- Next technical issue: #18 Streamlit Community Cloud deployment prep, the first Phase 1C issue.
+- Recent merged PRs: #34 docs wrap, #35 README screenshot polish, #38 pytest CI, #39 stale artifact cleanup.
 - Final README screenshots live in `docs/screenshots/` and should remain unchanged unless a focused screenshot task requires it.
 - Local screenshot candidates were moved outside the repo to `C:\Users\user\Desktop\policy-dispute-screenshot-candidates-archive\`.
 - Preserve research prototype, AI-generated, not-legal-advice, and demo-safe framing.
 - Keep work one issue per PR.
-- Phase 2 means the model/speed refactor: Responses API, Structured Outputs, stage-specific model configuration, speed/pipeline work, and benchmarking.
+- True Phase 2 remains reserved for the model/speed/API refactor: Responses API, Structured Outputs, stage-specific model configuration, speed/pipeline work, and benchmarking.
 - Prompt rewrites, report schema changes, backend rebuild, auth, users, billing, and storage are out of scope across all phases unless a future explicit issue changes that boundary.
 - Do not commit secrets, real client data, real claim names, claim numbers, or fake client proof.


### PR DESCRIPTION
Summary:
- Documents that #20 walkthrough video and screenshot recipe remains open but is intentionally deferred to a future brand/content walkthrough session.
- Confirms Phase 1B technical closeout is complete with #19 GitHub Actions CI for pytest and #22 stale `frontend/data/` artifact cleanup.
- Confirms Phase 1C may begin with #18 Streamlit Community Cloud deployment prep.
- Reiterates that true Phase 2 remains reserved for model/speed/API refactor work.

Scope:
- Docs-only.
- No app code, deployment config, CI workflow, prompts, schemas, model/API behavior, backend architecture, screenshots, or archived docs changed.