### PR TITLE
[codex] Harden demo section map loading

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -308,6 +308,7 @@ def _load_demo_assets() -> Tuple[Dict[str, Any], Dict[str, Any]]:
 def _load_demo_into_session() -> None:
     try:
         policy_result, dispute_result = _load_demo_assets()
+        section_map = _load_demo_section_map()
     except FileNotFoundError as exc:
         st.error(str(exc))
         st.stop()
@@ -317,7 +318,7 @@ def _load_demo_into_session() -> None:
 
     st.session_state[SESSION_KEY_POLICY] = policy_result
     st.session_state[SESSION_KEY_DISPUTE] = dispute_result
-    st.session_state[SESSION_KEY_SECTION_MAP] = _load_demo_section_map()
+    st.session_state[SESSION_KEY_SECTION_MAP] = section_map
     st.session_state[SESSION_KEY_CLAIM_METADATA] = {
         "nickname": "Demo Mode",
         "state": "",

--- a/tests/test_demo_mode_loading.py
+++ b/tests/test_demo_mode_loading.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+
+import frontend.app as app
+
+
+class _StreamlitStop(RuntimeError):
+    pass
+
+
+class _FakeStreamlit:
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+        self.session_state: dict[str, object] = {}
+
+    def error(self, message: object) -> None:
+        self.errors.append(str(message))
+
+    def stop(self) -> None:
+        raise _StreamlitStop()
+
+
+@pytest.mark.parametrize(
+    ("asset_text", "expected_error"),
+    [
+        ("{not valid json", "Failed to load demo assets:"),
+        ("[]", "JSON object mapping section names to text"),
+    ],
+)
+def test_invalid_demo_section_map_uses_demo_asset_failure_path(
+    tmp_path, monkeypatch, asset_text: str, expected_error: str
+) -> None:
+    section_text_path = tmp_path / "section_text.json"
+    section_text_path.write_text(asset_text, encoding="utf-8")
+    fake_st = _FakeStreamlit()
+
+    monkeypatch.setattr(app, "DEMO_SECTION_TEXT_PATH", section_text_path)
+    monkeypatch.setattr(app, "st", fake_st)
+    monkeypatch.setattr(app, "_load_demo_assets", lambda: ({"ok": True}, {"ok": True}))
+
+    with pytest.raises(_StreamlitStop):
+        app._load_demo_into_session()
+
+    assert len(fake_st.errors) == 1
+    assert "Failed to load demo assets:" in fake_st.errors[0]
+    assert expected_error in fake_st.errors[0]
+    assert app.SESSION_KEY_POLICY not in fake_st.session_state
+    assert app.SESSION_KEY_DISPUTE not in fake_st.session_state
+    assert app.SESSION_KEY_SECTION_MAP not in fake_st.session_state


### PR DESCRIPTION
## Summary

Follow-up to PR #41. This hardens Demo Mode citation source accordion loading so malformed or invalid `assets/demo/section_text.json` failures route through the same user-facing demo asset failure path as other demo asset failures.

## Changes

- Load the demo section source map inside `_load_demo_into_session`'s existing demo asset error handling path.
- Keep session state untouched when the section source-map asset is invalid.
- Add focused coverage for malformed JSON and non-object JSON section source-map assets.

## Validation

- `python -m pytest tests\test_demo_mode_loading.py tests\test_demo_citation_asset.py -q` -> 4 passed
- `python -m pytest -q` -> 24 passed
- Streamlit AppTest Demo Mode smoke with `DEMO_FORCE_ON=true` -> passed

## Out of scope

- No #18 deployment prep.
- No #23 export context work.
- No LLM prompt changes.
- No report schema changes.
- No model/API/backend architecture changes.
- No auth, users, billing, storage, or Streamlit Cloud config.
- No changes to secrets, real client data, screenshots, deployment docs, archived artifacts, or Demo Mode framing.