### PR TITLE
[codex] Add export report context

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -4,6 +4,7 @@ import importlib
 import json
 import sys
 import time
+from datetime import date
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
@@ -487,13 +488,46 @@ def _dict_to_dispute_report(d: Dict[str, Any]) -> DisputeReport:
     )
 
 
+def _build_export_context(
+    *,
+    claim_metadata: Dict[str, Any] | None = None,
+    policy_filename: str | None = None,
+    denial_filename: str | None = None,
+    demo_mode: bool = False,
+) -> Dict[str, Any]:
+    claim_metadata = claim_metadata or {}
+    context: Dict[str, Any] = {"generated_date": date.today().isoformat()}
+
+    nickname = str(claim_metadata.get("nickname", "") or "").strip()
+    if nickname:
+        context["claim_title"] = nickname
+
+    carrier = str(claim_metadata.get("carrier", "") or "").strip()
+    if carrier:
+        context["carrier"] = carrier
+
+    state = str(claim_metadata.get("state", "") or "").strip()
+    if state:
+        context["state"] = state
+
+    if policy_filename:
+        context["policy_filename"] = policy_filename
+    if denial_filename:
+        context["denial_filename"] = denial_filename
+    if demo_mode:
+        context["demo_mode"] = True
+
+    return context
+
+
 def _render_hero(
     dispute_report: Dict[str, Any],
-    dispute_markdown: str,
     policy_label: str,
     denial_label: str,
     policy_filename: str | None = None,
     denial_filename: str | None = None,
+    claim_metadata: Dict[str, Any] | None = None,
+    demo_mode: bool = False,
 ) -> None:
     st.subheader("Dispute overview")
 
@@ -551,17 +585,31 @@ def _render_hero(
             except (TypeError, ValueError):
                 st.write(f"**Confidence:** {score}")
 
-        st.markdown("##### Actions")
+        report_obj = _dict_to_dispute_report(dispute_report)
+        export_context = _build_export_context(
+            claim_metadata=claim_metadata,
+            policy_filename=policy_filename,
+            denial_filename=denial_filename,
+            demo_mode=demo_mode,
+        )
+        export_docx = render_dispute_docx(report_obj, context=export_context)
+        export_markdown = render_dispute_markdown(report_obj, context=export_context)
+
+        st.markdown("##### Exports")
         st.caption("Download the full A–G dispute write-up.")
+        st.markdown("**Human-friendly exports**")
+        st.caption("For human review, sharing draft notes, or offline review.")
         st.download_button(
-            "Download as Word (.docx)",
-            data=render_dispute_docx(_dict_to_dispute_report(dispute_report)),
+            "Word/DOCX report",
+            data=export_docx,
             file_name=f"{policy_label}__{denial_label}.dispute.docx",
             mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         )
+        st.markdown("**AI / workflow-friendly exports**")
+        st.caption("For AI agents, automation, technical review, and workflow handoff.")
         st.download_button(
-            "Download as Markdown",
-            data=dispute_markdown,
+            "Markdown report",
+            data=export_markdown,
             file_name=f"{policy_label}__{denial_label}.dispute.md",
             mime="text/markdown",
         )
@@ -884,7 +932,17 @@ def _run_full_analysis(
         )
         dispute_obj.denial_id = Path(denial_path).stem or "denial"
 
-        markdown = render_dispute_markdown(dispute_obj)
+        markdown = render_dispute_markdown(
+            dispute_obj,
+            context=_build_export_context(
+                claim_metadata={
+                    "nickname": claim_nickname.strip(),
+                    "state": state.strip(),
+                },
+                policy_filename=policy_file.name,
+                denial_filename=denial_file.name,
+            ),
+        )
         dispute_report_dict = dispute_obj.to_dict()
 
         dispute_result: Dict[str, Any] = {
@@ -1024,11 +1082,12 @@ def _render_results_section() -> None:
 
     _render_hero(
         dispute_report,
-        dispute_result.get("markdown", "") or "",
         policy_label,
         denial_label,
         policy_filename=claim_metadata.get("policy_filename"),
         denial_filename=claim_metadata.get("denial_filename"),
+        claim_metadata=claim_metadata,
+        demo_mode=bool(st.session_state.get(SESSION_KEY_DEMO_MODE)),
     )
 
     st.markdown("### Detailed dispute views")
@@ -1120,11 +1179,14 @@ def _render_claim_history_page() -> None:
 
             _render_hero(
                 dispute_report,
-                dispute_result.get("markdown", "") or "",
                 policy_label,
                 denial_label,
                 policy_filename=claim.policy_filename,
                 denial_filename=claim.denial_filename,
+                claim_metadata={
+                    "nickname": claim.nickname,
+                    "state": claim.state,
+                },
             )
 
             st.markdown("### Detailed dispute views")

--- a/src/report_builder.py
+++ b/src/report_builder.py
@@ -4,6 +4,7 @@ import argparse
 import io
 import json
 from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 from typing import Any, Dict, List, Iterable
 
@@ -234,7 +235,61 @@ def main() -> None:
     print(f"[bold]Done.[/bold] Built {count} report file(s).")
 
 
-def render_dispute_markdown(report: DisputeReport) -> str:
+def _clean_context_value(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _generated_date(context: Dict[str, Any] | None) -> str:
+    if context:
+        explicit = _clean_context_value(
+            context.get("generated_date") or context.get("generated_at")
+        )
+        if explicit:
+            return explicit
+    return date.today().isoformat()
+
+
+def _export_context_rows(
+    report: DisputeReport,
+    context: Dict[str, Any] | None = None,
+) -> List[tuple[str, str]]:
+    context = context or {}
+    rows: List[tuple[str, str]] = []
+
+    for label, key in [
+        ("Claim", "claim_title"),
+        ("Carrier", "carrier"),
+        ("State", "state"),
+    ]:
+        value = _clean_context_value(context.get(key))
+        if value:
+            rows.append((label, value))
+
+    rows.append(("Generated date", _generated_date(context)))
+
+    if report.policy_id:
+        rows.append(("Policy ID", str(report.policy_id)))
+    if report.denial_id:
+        rows.append(("Denial ID", str(report.denial_id)))
+
+    for label, key in [
+        ("Policy file", "policy_filename"),
+        ("Denial file", "denial_filename"),
+    ]:
+        value = _clean_context_value(context.get(key))
+        if value:
+            rows.append((label, value))
+
+    if context.get("demo_mode"):
+        rows.append(("Mode", "Demo Mode"))
+
+    return rows
+
+
+def render_dispute_markdown(
+    report: DisputeReport,
+    context: Dict[str, Any] | None = None,
+) -> str:
     """
     Render a DisputeReport (A–G structure) to Markdown.
     """
@@ -245,14 +300,12 @@ def render_dispute_markdown(report: DisputeReport) -> str:
     lines.append(f"# {title}")
     lines.append("")
 
-    meta_lines: List[str] = []
-    if report.policy_id:
-        meta_lines.append(f"- Policy: `{report.policy_id}`")
-    if report.denial_id:
-        meta_lines.append(f"- Denial: `{report.denial_id}`")
-
-    if meta_lines:
-        lines.extend(meta_lines)
+    context_rows = _export_context_rows(report, context)
+    if context_rows:
+        lines.append("## Report context")
+        lines.append("")
+        for label, value in context_rows:
+            lines.append(f"- **{label}:** {value}")
         lines.append("")
 
     lines.append(
@@ -360,7 +413,10 @@ def render_dispute_markdown(report: DisputeReport) -> str:
     return "\n".join(lines)
 
 
-def render_dispute_docx(report: DisputeReport) -> bytes:
+def render_dispute_docx(
+    report: DisputeReport,
+    context: Dict[str, Any] | None = None,
+) -> bytes:
     """
     Render a DisputeReport (A–G structure) to a Word document (.docx).
 
@@ -378,14 +434,13 @@ def render_dispute_docx(report: DisputeReport) -> bytes:
     title.alignment = WD_PARAGRAPH_ALIGNMENT.CENTER
 
     # Metadata
-    if report.policy_id or report.denial_id:
-        meta_para = doc.add_paragraph()
-        if report.policy_id:
-            meta_para.add_run(f"Policy: {report.policy_id}").bold = True
-            if report.denial_id:
-                meta_para.add_run("  |  ")
-        if report.denial_id:
-            meta_para.add_run(f"Denial: {report.denial_id}").bold = True
+    context_rows = _export_context_rows(report, context)
+    if context_rows:
+        doc.add_heading("Report Context", level=1)
+        for label, value in context_rows:
+            para = doc.add_paragraph()
+            para.add_run(f"{label}: ").bold = True
+            para.add_run(value)
 
     # Framing disclaimer
     disclaimer = doc.add_paragraph()

--- a/tests/test_report_export_context.py
+++ b/tests/test_report_export_context.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import io
+
+from docx import Document
+
+from src.report_builder import render_dispute_docx, render_dispute_markdown
+from src.schemas import ConfidenceBlock, DisputeReport, Point
+
+
+def _sample_report() -> DisputeReport:
+    return DisputeReport(
+        policy_id="policy-123",
+        denial_id="denial-456",
+        plain_summary="The dispute summary.",
+        coverage_highlights=[Point(text="Coverage may apply.", citation="Coverage A")],
+        confidence=ConfidenceBlock(score=0.5, notes="Review source files."),
+    )
+
+
+def test_dispute_markdown_export_includes_human_context() -> None:
+    markdown = render_dispute_markdown(
+        _sample_report(),
+        context={
+            "claim_title": "Kitchen water loss",
+            "carrier": "Example Carrier",
+            "state": "TX",
+            "generated_date": "2026-04-26",
+            "policy_filename": "policy.pdf",
+            "denial_filename": "denial.pdf",
+            "demo_mode": True,
+        },
+    )
+
+    assert "## Report context" in markdown
+    assert "- **Claim:** Kitchen water loss" in markdown
+    assert "- **Carrier:** Example Carrier" in markdown
+    assert "- **State:** TX" in markdown
+    assert "- **Generated date:** 2026-04-26" in markdown
+    assert "- **Policy file:** policy.pdf" in markdown
+    assert "- **Denial file:** denial.pdf" in markdown
+    assert "- **Mode:** Demo Mode" in markdown
+    assert "AI-generated analysis" in markdown
+    assert "not legal advice" in markdown
+
+
+def test_dispute_markdown_export_handles_no_context() -> None:
+    markdown = render_dispute_markdown(_sample_report())
+
+    assert "## Report context" in markdown
+    assert "- **Policy ID:** policy-123" in markdown
+    assert "- **Denial ID:** denial-456" in markdown
+    assert "## A. Plain-English overview of the dispute" in markdown
+
+
+def test_dispute_docx_export_includes_human_context() -> None:
+    docx_bytes = render_dispute_docx(
+        _sample_report(),
+        context={
+            "claim_title": "Kitchen water loss",
+            "state": "TX",
+            "generated_date": "2026-04-26",
+            "policy_filename": "policy.pdf",
+            "denial_filename": "denial.pdf",
+        },
+    )
+
+    document = Document(io.BytesIO(docx_bytes))
+    text = "\n".join(paragraph.text for paragraph in document.paragraphs)
+
+    assert "Report Context" in text
+    assert "Claim: Kitchen water loss" in text
+    assert "State: TX" in text
+    assert "Generated date: 2026-04-26" in text
+    assert "Policy file: policy.pdf" in text
+    assert "Denial file: denial.pdf" in text


### PR DESCRIPTION
## Summary

Closes #23.

Adds human-readable context to dispute report exports without changing the A-G report schema. Markdown and Word/DOCX renderers now accept optional export context for claim title/nickname, carrier when available, state, generated date, policy/denial IDs, filenames, and Demo Mode.

The Streamlit export area now separates formats by intended audience:

- Human-friendly exports: Word/DOCX report
- AI / workflow-friendly exports: Markdown report

## Validation

- `python -m pytest tests\test_report_export_context.py -q` -> 3 passed
- `python -m pytest -q` -> 27 passed
- `git diff --check` -> passed

## Manual export check notes

- Demo Mode Markdown export smoke: generated report includes `Report context`, `Claim: Demo Mode`, generated date, `demo.json`, `demo.report.md`, `Mode: Demo Mode`, and not-legal-advice framing.
- Demo Mode Word/DOCX export smoke: generated `.docx` opens with python-docx and includes the same report context fields.
- Demo Mode AppTest smoke: export UI renders both `Human-friendly exports` and `AI / workflow-friendly exports` groups.

## Export grouping notes

DOCX is framed as the human-friendly report for review/sharing/offline use. Markdown remains available and is framed for AI agents, automation, technical review, and workflow handoff.

## PDF export

PDF export is deferred. This PR does not add PDF generation because there is no obvious dependency-light path in the current code, and adding PDF would require separate rendering/layout work or heavier tooling.

## Out of scope

- No #18 deployment prep.
- No #20 walkthrough docs.
- No Phase 2 model/API refactor work.
- No LLM prompt changes.
- No report schema changes.
- No backend architecture rebuild.
- No auth, users, billing, server-side storage, Streamlit Cloud config, or deployment docs.
- No heavy PDF dependencies or PDF export implementation.
- No real client data, secrets, screenshots, archived artifacts, API changes, or prompt/schema changes.