### PR TITLE
docs: wrap Phase 1 and prep Phase 2 baseline benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 AI assistant for turning homeowners policies and denial letters into dispute‑focused summaries (A–G structure) for public adjusters and attorneys.
 
-> **Status:** Internal prototype / demo, with Phase 1 demo-hardening complete
+> **Status:** Internal prototype / demo, with Phase 1 complete (1A demo polish, 1B technical closeout, 1C local/demo trust polish)
 >
 > **Frontend:** Streamlit v1 UX (`frontend/app.py`)
 >
@@ -299,7 +299,12 @@ This repo is meant for **local experiments**, not production.
 
 ## Roadmap / ideas
 
-Phase 1A demo polish and Phase 1B technical closeout are complete. #20 walkthrough video and screenshot recipe remains open, but is intentionally deferred to a future brand/content walkthrough session. Phase 1C may begin with #18 Streamlit Community Cloud deployment prep. True Phase 2 remains reserved for model/speed/API refactor work. Full sequencing lives in `docs/03-roadmap.md`.
+Phase 1 is complete. Phase 1A demo polish, Phase 1B technical closeout, and Phase 1C local/demo trust polish are done.
+
+- #18 Streamlit Community Cloud deployment prep is intentionally deferred until a hosted public demo is needed.
+- #20 walkthrough video/screenshot recipe is intentionally deferred until after Phase 2 model/API/speed upgrades stabilize.
+- Phase 2 starts with baseline benchmarking before Responses API, Structured Outputs, or model-config work.
+- Full sequencing lives in `docs/03-roadmap.md`.
 
 If you experiment with the repo and find issues or ideas, feel free to open GitHub Issues or PRs.
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -81,9 +81,10 @@ The canonical local artifact location is the repository-root `data/` directory:
 
 ### Streamlit boots but errors when demo mode is on
 
-- Confirm both files exist:
+- Confirm all three demo files exist:
   - `assets/demo/demo.json`
   - `assets/demo/demo.report.md`
+  - `assets/demo/section_text.json`
 
 ### Live mode fails due to missing key
 

--- a/docs/01-current-state.md
+++ b/docs/01-current-state.md
@@ -2,7 +2,7 @@
 
 Last updated: 2026-04-25
 
-Phase 1A demo polish is complete. The app remains a Streamlit research prototype with deterministic Demo Mode, a live API-backed local workflow, README screenshots, and explicit AI-generated / not-legal-advice framing.
+Phase 1 is complete. The app remains a Streamlit research prototype with deterministic Demo Mode, a live API-backed local workflow, README screenshots, and explicit AI-generated / not-legal-advice framing.
 
 ## Completed Phase 1A Issues
 
@@ -19,16 +19,23 @@ Phase 1A demo polish is complete. The app remains a Streamlit research prototype
 - PR #35: README screenshot polish with five committed demo-safe screenshots.
 - PR #38: GitHub Actions CI for pytest.
 - PR #39: stale `frontend/data/` artifact cleanup and runtime artifact docs.
+- PR #41: Demo Mode citation/source accordions.
+- PR #42: Demo source-map loading hardening.
+- PR #43: human-readable export context and human/AI export grouping.
 
 ## Current Phase
 
+Phase 1A demo polish is complete.
+
 Phase 1B technical closeout is complete with #19 GitHub Actions CI for pytest and #22 stale `frontend/data/` artifact cleanup.
 
-#20 walkthrough video and screenshot recipe remains open, but it is intentionally deferred to a future brand/content walkthrough session.
+Phase 1C local/demo trust polish is complete with #21 Demo Mode citation/source accordions, Demo source-map loading hardening, and #23 export context polish.
 
-Phase 1C technical work may begin with #18 Streamlit Community Cloud deployment prep. Phase 1C also includes #21 Demo Mode citation/source accordions and #23 export context polish.
+#18 Streamlit Community Cloud deployment prep is intentionally deferred because hosted deployment is not needed yet and adds surface area.
 
-True Phase 2 remains reserved for model/speed/API refactor work. No deployment config, citation accordion update, export polish, model/API modernization, prompt changes, schema changes, backend rebuild, auth, users, billing, or storage changes have been started.
+#20 walkthrough video and screenshot recipe is intentionally deferred because walkthrough/video work should wait until after Phase 2 stabilizes.
+
+Next step is Phase 2 baseline benchmarking. No Phase 2 implementation has started.
 
 ## Local Cleanup
 

--- a/docs/03-roadmap.md
+++ b/docs/03-roadmap.md
@@ -17,32 +17,38 @@ Completed:
 - #22 Clean up stale `frontend/data/` artifacts.
 
 Note:
-#20 walkthrough video and screenshot recipe remains open, but it is intentionally deferred to a future brand/content walkthrough session. Do not mix it into technical hardening sessions.
+#20 walkthrough video and screenshot recipe is intentionally deferred until after Phase 2 stabilizes. Do not mix it into technical hardening sessions.
 
-## Phase 1C: Hosted demo and trust polish - next
+## Phase 1C: Local/demo trust polish - completed
 
-Work one issue per PR, in this order:
+Completed:
 
-1. #18 Streamlit Community Cloud deployment prep.
-2. #21 Citation/source accordions in Demo Mode.
-3. #23 Human-readable context in dispute report exports.
+- #21 Demo Mode citation/source accordions via PR #41.
+- Demo source-map loading hardening via PR #42.
+- #23 human-readable export context and human/AI export grouping via PR #43.
 
-Note:
-Deployment prep may come before citation accordions, but the hosted demo should not be publicly promoted as a final portfolio demo until the Demo Mode citation/source accordion work is complete.
+Intentionally deferred:
+
+- #18 Streamlit Community Cloud deployment prep - revisit only when a hosted public demo is needed.
+- #20 walkthrough video/screenshot recipe - revisit after Phase 2 stabilizes.
 
 ## Phase 2: Model and speed refactor - not started
 
-True Phase 2 remains reserved for model/speed/API refactor work. Begin only after Phase 1A, 1B, and 1C are complete or intentionally deferred, and only after focused inspection or measurement.
+True Phase 2 remains reserved for model/speed/API refactor work. Begin only after Phase 1A, 1B, and 1C are complete or intentionally deferred, and only after baseline measurement.
 
-Scope:
+Gating rule:
 
-- Replace the Chat Completions wrapper with the Responses API.
-- Add Structured Outputs schemas for sectioning and dispute report generation.
-- Add stage-specific model configuration.
-- Parallelize or reduce per-section LLM calls.
-- Add a focused-analysis mode that targets the most material sections.
-- Remove redundant PDF reprocessing in the live pipeline.
-- Add a benchmark report comparing latency, cost, and report quality before and after.
+Do not start Responses API or Structured Outputs work before baseline measurements exist.
+
+Order:
+
+1. Baseline benchmarking and current-state measurement: end-to-end latency, cost per claim, per-section token usage, and quality snapshot against the demo bundle.
+2. Replace the Chat Completions wrapper with the Responses API.
+3. Add Structured Outputs schemas for sectioning and dispute report generation.
+4. Add stage-specific model configuration.
+5. Speed work: parallelize per-section LLM calls and remove redundant PDF reprocessing in the live pipeline.
+6. Add focused-analysis mode.
+7. Final benchmark report comparing latency, cost, and report quality against the Phase 2 baseline.
 
 ## Out of scope across all phases
 

--- a/docs/05-decision-log.md
+++ b/docs/05-decision-log.md
@@ -21,3 +21,10 @@ Phase 1B should begin with #19 GitHub Actions CI for pytest before stale artifac
 ### Defer model/API modernization to Phase 2
 
 Responses API migration, Structured Outputs, stage-specific model configuration, and speed/pipeline work are true Phase 2 model/speed refactor items. They are deferred until after Phase 1B and Phase 1C are complete or intentionally deferred, and only after focused inspection or measurement.
+
+## 2026-04-25 - Phase 1C wrap
+
+- Mark Phase 1 complete after Phase 1C technical closeout.
+- Defer #18 Streamlit Community Cloud deployment prep.
+- Defer #20 walkthrough video and screenshot recipe.
+- Require Phase 2 to start with baseline benchmarking.

--- a/docs/06-heartbeat.md
+++ b/docs/06-heartbeat.md
@@ -4,19 +4,19 @@ Date: 2026-04-25
 
 ## Status
 
-- Phase 1A demo polish is complete.
-- Phase 1B technical closeout is complete with #19 GitHub Actions CI for pytest and #22 stale `frontend/data/` artifact cleanup.
-- #20 walkthrough video and screenshot recipe remains open but is intentionally deferred to a future brand/content walkthrough session.
-- Phase 1C hosted demo and trust polish has not started.
-- Phase 2 model/speed refactor has not started.
-- The next technical issue is #18: Streamlit Community Cloud deployment prep.
+- Phase 1A demo polish: complete.
+- Phase 1B technical closeout: complete.
+- Phase 1C local/demo trust polish: complete via PR #41, PR #42, and PR #43.
+- #18 deployment prep: intentionally deferred.
+- #20 walkthrough/video recipe: intentionally deferred until after Phase 2 stabilizes.
+- Phase 2 model/speed refactor: not started.
+- Next step: baseline benchmarking.
 
 ## Current Watchouts
 
-- Keep phase boundaries clear. Phase 1C may begin with #18 Streamlit Community Cloud deployment prep.
-- Do not start #20 during technical hardening; defer it to a future brand/content walkthrough session.
-- Do not mix Phase 2 model/API refactor work into Phase 1B or Phase 1C PRs.
-- Do not start model/API modernization before Phase 1B/1C completion or intentional deferral, inspection, and measurement.
+- Keep phase boundaries clear. #18 and #20 are intentionally deferred, not missing from the roadmap.
+- Do not start Responses API, Structured Outputs, model swaps, or speed refactors before baseline benchmarking exists.
+- Do not mix Phase 2 implementation work into docs-only wrap PRs.
 - Do not change prompts or report schemas as part of docs, CI, or deployment work.
 - Keep public-demo safety centered on deterministic Demo Mode and `DEMO_FORCE_ON`.
 - Do not commit local runtime artifacts, real claim data, secrets, or screenshot candidates.

--- a/docs/07-quality-gates.md
+++ b/docs/07-quality-gates.md
@@ -26,6 +26,8 @@
 - Validate API-backed work with non-sensitive sample files only.
 - Always compare generated reports against the source policy and denial; output is AI-generated.
 
-## Future CI
+## CI
 
-#19 should add GitHub Actions CI for `python -m pytest -q`. Until then, local pytest output is the primary automated validation signal.
+- GitHub Actions runs `python -m pytest -q` on every push and PR via `.github/workflows/ci.yml`.
+- README CI badge reflects the latest run.
+- Local pytest remains the fastest signal; CI is the merge gate.

--- a/docs/08-memory.md
+++ b/docs/08-memory.md
@@ -5,12 +5,12 @@ Durable context for future Codex and Claude sessions.
 - Repo: `policy-dispute-ai-assistant`.
 - Current branch baseline: `main`.
 - Phase 1A demo polish is complete.
-- Phase 1B technical closeout is complete with #19 GitHub Actions CI for pytest and #22 stale `frontend/data/` artifact cleanup.
-- #20 walkthrough video and screenshot recipe remains open but is intentionally deferred to a future brand/content walkthrough session.
-- Phase 1C hosted demo and trust polish has not started.
+- Phase 1B technical closeout is complete.
+- Phase 1C local/demo trust polish is complete.
+- #18 Streamlit Community Cloud deployment prep and #20 walkthrough video/screenshot recipe are intentionally deferred.
 - Phase 2 model/speed refactor has not started.
-- Next technical issue: #18 Streamlit Community Cloud deployment prep, the first Phase 1C issue.
-- Recent merged PRs: #34 docs wrap, #35 README screenshot polish, #38 pytest CI, #39 stale artifact cleanup.
+- Next: Phase 2 baseline benchmarking. Do not start Responses API, Structured Outputs, or model swaps before the baseline exists.
+- Recent merged PRs: #34 docs wrap, #35 README screenshot polish, #38 pytest CI, #39 stale artifact cleanup, #41 Demo Mode citation/source accordions, #42 Demo source-map loading hardening, #43 export context polish.
 - Final README screenshots live in `docs/screenshots/` and should remain unchanged unless a focused screenshot task requires it.
 - Local screenshot candidates were moved outside the repo to `C:\Users\user\Desktop\policy-dispute-screenshot-candidates-archive\`.
 - Preserve research prototype, AI-generated, not-legal-advice, and demo-safe framing.


### PR DESCRIPTION
﻿## Summary
- Wraps Phase 1 as complete across durable docs.
- Records #18 and #20 as intentional deferrals, not forgotten items.
- Makes Phase 2 start with baseline benchmarking before Responses API, Structured Outputs, model config, or speed work.

## Files changed
- README.md
- RUNBOOK.md
- docs/01-current-state.md
- docs/03-roadmap.md
- docs/05-decision-log.md
- docs/06-heartbeat.md
- docs/07-quality-gates.md
- docs/08-memory.md

## Validation grep results
- `git status --short`: only the 8 scoped files were changed before commit.
- `git grep -n "Phase 1C has not started" -- docs`: no matches.
- `git grep -n "next technical issue is #18" -- docs`: no matches.
- `git grep -n "Future CI" -- docs/07-quality-gates.md`: no matches.
- `git grep -n "section_text.json" -- RUNBOOK.md`: RUNBOOK.md:34, RUNBOOK.md:49, RUNBOOK.md:87.
- `git grep -n "Baseline benchmarking" -- docs/03-roadmap.md`: docs/03-roadmap.md:45.
- `git diff --check`: passed.

## Deferrals
#18 Streamlit Community Cloud deployment prep and #20 walkthrough video/screenshot recipe are intentionally deferred, not forgotten.

## Out of scope
- No code, tests, CI, deployment config, Streamlit Cloud docs, secrets templates, screenshots, archived docs, logs, prompts, schemas, model/API work, backend architecture changes, auth, users, billing, storage, or PDF export work.
- Tests were not run because this is a docs-only PR.
