### PR TITLE
docs: standardize project history and session logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ For current project status, architecture, roadmap, and agent workflow notes, sta
 - `docs/03-roadmap.md`
 - `docs/04-agent-workflow.md`
 
+Durable project history lives in:
+
+- `docs/05-decision-log.md`
+- `docs/06-heartbeat.md`
+- `docs/08-memory.md`
+- `docs/09-session-log.md`
+
 ---
 
 ## Repo structure

--- a/docs/04-agent-workflow.md
+++ b/docs/04-agent-workflow.md
@@ -24,14 +24,22 @@ Use this workflow for Codex, Claude Code, and future agent sessions.
 
 ## Session Logging
 
-Use lightweight session logs when a session is more than a quick one-command maintenance task.
+Use `docs/09-session-log.md` for meaningful sessions that change project direction, durable docs, or implementation state.
 
-- Create a new `logs/YYYY-MM-DD_<topic>.md` from `logs/SESSION_TEMPLATE.md` at the start of the session.
-- Keep logs short.
-- Capture Goal, Decisions, Friction, Next - Immediate, and Restart Test.
-- Do not edit `logs/SESSION_TEMPLATE.md` directly.
+- Keep entries short.
+- Capture Goal, Completed, Decisions, Validation, Deferred, and Next session starter.
+- Do not use `logs/` unless the issue explicitly requires archival session artifacts.
 
-See `logs/README.md` and `logs/SESSION_TEMPLATE.md`.
+## Session closeout protocol
+
+At the end of a meaningful session:
+
+1. Update `docs/06-heartbeat.md` with current truth and next action.
+2. Add a `docs/09-session-log.md` entry.
+3. Add a `docs/05-decision-log.md` entry only if a meaningful decision was made.
+4. Update `docs/08-memory.md` only for durable milestones, not routine work.
+5. Keep docs concise and factual.
+6. Do not update archive/log/screenshot files unless the issue explicitly requires it.
 
 ## PR Closeout
 

--- a/docs/05-decision-log.md
+++ b/docs/05-decision-log.md
@@ -1,30 +1,101 @@
 # Decision Log
 
-## 2026-04-25
+Use this format for future entries:
 
-### Preserve research and not-legal-advice framing
+## YYYY-MM-DD HH:MM ET — Decision title
 
-The app stays framed as an educational research prototype. It is not a legal product, not a coverage decision, and not a replacement for professional review.
+### Context
+- What problem or tradeoff existed.
 
-### Force Demo Mode for hosted public demos
+### Decision
+- What we decided.
 
-Hosted demos should use `DEMO_FORCE_ON=true` so uploads and live API-backed analysis are disabled and deterministic demo-safe artifacts are used.
+### Consequence
+- What this changes or prevents.
 
-### Finish README screenshots before Phase 1B
+### Revisit trigger
+- When this decision should be reconsidered.
 
-README screenshots and first-impression polish were completed before Phase 1B operational closeout so visitors see the current v1 UX without relying on stale issue notes.
+## 2026-04-25 15:42 ET — Force Demo Mode for hosted public demos
 
-### Begin Phase 1B with CI
+### Context
+- Hosted demos need to be deterministic and should not accept uploads or make live API calls.
 
-Phase 1B should begin with #19 GitHub Actions CI for pytest before stale artifact cleanup or walkthrough recipe work.
+### Decision
+- Use `DEMO_FORCE_ON=true` for hosted public demos.
 
-### Defer model/API modernization to Phase 2
+### Consequence
+- Hosted demos use tracked demo-safe artifacts and disable live analysis paths.
 
-Responses API migration, Structured Outputs, stage-specific model configuration, and speed/pipeline work are true Phase 2 model/speed refactor items. They are deferred until after Phase 1B and Phase 1C are complete or intentionally deferred, and only after focused inspection or measurement.
+### Revisit trigger
+- Reconsider when hosted deployment is actively needed and the public-demo threat model changes.
 
-## 2026-04-25 - Phase 1C wrap
+## 2026-04-25 17:37 ET — Preserve research and not-legal-advice framing
 
-- Mark Phase 1 complete after Phase 1C technical closeout.
-- Defer #18 Streamlit Community Cloud deployment prep.
-- Defer #20 walkthrough video and screenshot recipe.
-- Require Phase 2 to start with baseline benchmarking.
+### Context
+- The app needs demo polish without implying production readiness, legal advice, or real claim outcomes.
+
+### Decision
+- Keep the app framed as an educational research prototype, not a legal product or coverage decision.
+
+### Consequence
+- README, UI copy, screenshots, and generated reports must preserve AI-generated and not-legal-advice framing.
+
+### Revisit trigger
+- Reconsider only if the project scope changes from research prototype to a reviewed production product.
+
+## 2026-04-25 18:24 ET — Finish README screenshots before Phase 1B
+
+### Context
+- The repo needed accurate first-impression material before operational closeout.
+
+### Decision
+- Complete README screenshots and repo polish before Phase 1B technical work.
+
+### Consequence
+- Visitors can understand the current v1 UX without relying on stale issue notes.
+
+### Revisit trigger
+- Revisit when UI changes make committed screenshots materially inaccurate.
+
+## 2026-04-25 19:24 ET — Begin Phase 1B with CI
+
+### Context
+- Technical closeout needed a reliable automated signal before more cleanup.
+
+### Decision
+- Start Phase 1B with #19 GitHub Actions CI for `python -m pytest -q`.
+
+### Consequence
+- CI became the merge gate while local pytest remained the fastest development signal.
+
+### Revisit trigger
+- Revisit when test coverage or dependency setup changes enough to require a different CI shape.
+
+## 2026-04-25 19:44 ET — Defer walkthrough recipe
+
+### Context
+- #20 walkthrough video/screenshot recipe was useful, but model/API/speed work would likely change the demo flow.
+
+### Decision
+- Defer #20 until after Phase 2 stabilizes.
+
+### Consequence
+- Docs avoid locking in a walkthrough before baseline, model/API, or speed work changes the experience.
+
+### Revisit trigger
+- Revisit after Phase 2 upgrades stabilize and a walkthrough can stay accurate.
+
+## 2026-04-25 21:42 ET — Phase 1C wrap
+
+### Context
+- Phase 1A demo polish, Phase 1B technical closeout, and Phase 1C local/demo trust polish were complete.
+
+### Decision
+- Mark Phase 1 complete, defer #18 Streamlit Community Cloud deployment prep, defer #20 walkthrough video/screenshot recipe, and require Phase 2 to start with baseline benchmarking.
+
+### Consequence
+- Phase 2 cannot start with Responses API, Structured Outputs, model swaps, or speed refactors before current-state measurements exist.
+
+### Revisit trigger
+- Revisit #18 only when a hosted public demo is needed; revisit #20 after Phase 2 stabilizes.

--- a/docs/06-heartbeat.md
+++ b/docs/06-heartbeat.md
@@ -1,23 +1,26 @@
 # Heartbeat
 
-Date: 2026-04-25
+Last updated: 2026-04-25 21:50 ET
 
-## Status
+## Current Phase
+- Phase 1 is complete: Phase 1A demo polish, Phase 1B technical closeout, and Phase 1C local/demo trust polish.
+- Phase 2 model/speed refactor has not started.
 
-- Phase 1A demo polish: complete.
-- Phase 1B technical closeout: complete.
-- Phase 1C local/demo trust polish: complete via PR #41, PR #42, and PR #43.
-- #18 deployment prep: intentionally deferred.
-- #20 walkthrough/video recipe: intentionally deferred until after Phase 2 stabilizes.
-- Phase 2 model/speed refactor: not started.
-- Next step: baseline benchmarking.
+## Current Truth
+- PR #44 wrapped Phase 1 and handed off to Phase 2 baseline benchmarking.
+- #21 Demo Mode citation/source accordions are complete via PR #41.
+- Demo source-map loading hardening is complete via PR #42.
+- #23 human-readable export context and human/AI export grouping are complete via PR #43.
+- The repo remains a research prototype with AI-generated and not-legal-advice framing.
 
-## Current Watchouts
+## Next Action
+- Start Phase 2 with baseline benchmarking and current-state measurement against the demo bundle.
 
-- Keep phase boundaries clear. #18 and #20 are intentionally deferred, not missing from the roadmap.
-- Do not start Responses API, Structured Outputs, model swaps, or speed refactors before baseline benchmarking exists.
-- Do not mix Phase 2 implementation work into docs-only wrap PRs.
-- Do not change prompts or report schemas as part of docs, CI, or deployment work.
-- Keep public-demo safety centered on deterministic Demo Mode and `DEMO_FORCE_ON`.
-- Do not commit local runtime artifacts, real claim data, secrets, or screenshot candidates.
-- Preserve the research prototype / not legal advice framing in README, UI, and generated reports.
+## Deferred
+- #18 Streamlit deployment prep — deferred because hosted deployment is not needed yet and adds surface area.
+- #20 walkthrough/video recipe — deferred until after Phase 2 model/API/speed upgrades stabilize.
+
+## Watchouts
+- Phase 2 must start with baseline benchmarking.
+- Do not start Responses API, Structured Outputs, model swaps, prompt changes, schema changes, or speed refactors before the baseline exists.
+- Preserve research prototype / AI-generated / not legal advice framing.

--- a/docs/08-memory.md
+++ b/docs/08-memory.md
@@ -1,20 +1,31 @@
 # Memory
 
-Durable context for future Codex and Claude sessions.
+Durable project timeline for future Codex and Claude sessions.
+
+## Current Baseline
 
 - Repo: `policy-dispute-ai-assistant`.
 - Current branch baseline: `main`.
-- Phase 1A demo polish is complete.
-- Phase 1B technical closeout is complete.
-- Phase 1C local/demo trust polish is complete.
+- Phase 1 is complete.
 - #18 Streamlit Community Cloud deployment prep and #20 walkthrough video/screenshot recipe are intentionally deferred.
-- Phase 2 model/speed refactor has not started.
-- Next: Phase 2 baseline benchmarking. Do not start Responses API, Structured Outputs, or model swaps before the baseline exists.
-- Recent merged PRs: #34 docs wrap, #35 README screenshot polish, #38 pytest CI, #39 stale artifact cleanup, #41 Demo Mode citation/source accordions, #42 Demo source-map loading hardening, #43 export context polish.
-- Final README screenshots live in `docs/screenshots/` and should remain unchanged unless a focused screenshot task requires it.
-- Local screenshot candidates were moved outside the repo to `C:\Users\user\Desktop\policy-dispute-screenshot-candidates-archive\`.
+- Phase 2 has not started.
+- Next: Phase 2 baseline benchmarking. Do not start Responses API, Structured Outputs, model swaps, prompt changes, schema changes, or speed refactors before the baseline exists.
+
+## Timeline
+
+| Date/Time ET | Event | Issue/PR | Why it matters |
+| --- | --- | --- | --- |
+| 2026-04-25 17:37 ET | Phase 1A demo polish wrapped | PR #34 | Established the demo-hardening baseline and research/not-legal-advice framing. |
+| 2026-04-25 19:24 ET | CI basics added | #19 / PR #38 | Made `python -m pytest -q` the automated merge gate. |
+| 2026-04-25 19:30 ET | Stale artifact cleanup documented | #22 / PR #39 | Clarified runtime artifact paths and removed stale `frontend/data/` confusion. |
+| 2026-04-25 20:36 ET | Demo citation/source accordions completed | #21 / PR #41 | Made bundled demo citations inspectable without live API calls. |
+| 2026-04-25 20:45 ET | Demo source-map loading hardened | PR #42 | Reduced fragility in deterministic demo source lookup. |
+| 2026-04-25 21:07 ET | Export context polish completed | #23 / PR #43 | Added human-readable export context and human/AI grouping. |
+| 2026-04-25 21:42 ET | Phase 1 wrapped and Phase 2 handoff recorded | PR #44 | Marked Phase 1 complete, deferred #18/#20, and required Phase 2 to start with baseline benchmarking. |
+
+## Standing Guardrails
+
 - Preserve research prototype, AI-generated, not-legal-advice, and demo-safe framing.
 - Keep work one issue per PR.
-- True Phase 2 remains reserved for the model/speed/API refactor: Responses API, Structured Outputs, stage-specific model configuration, speed/pipeline work, and benchmarking.
-- Prompt rewrites, report schema changes, backend rebuild, auth, users, billing, and storage are out of scope across all phases unless a future explicit issue changes that boundary.
 - Do not commit secrets, real client data, real claim names, claim numbers, or fake client proof.
+- Keep routine logs, archived docs, and screenshots unchanged unless an issue explicitly requires them.

--- a/docs/09-session-log.md
+++ b/docs/09-session-log.md
@@ -1,0 +1,76 @@
+# Session Log
+
+Purpose:
+Track real working sessions so future AI/dev sessions can quickly understand what happened, what changed, and what to do next.
+
+## Entry format
+
+### YYYY-MM-DD HH:MM ET — Short session title
+
+#### Goal
+- What this session was trying to accomplish.
+
+#### Completed
+- What changed.
+- PRs/issues touched.
+
+#### Decisions
+- Any decisions made.
+- Link to `docs/05-decision-log.md` when relevant.
+
+#### Validation
+- Tests/checks/run results, if any.
+
+#### Deferred
+- Anything intentionally postponed.
+
+#### Next session starter
+- The exact next recommended action.
+
+### 2026-04-25 21:07 ET — Phase 1C trust polish
+
+#### Goal
+- Complete local/demo trust polish after Phase 1A and Phase 1B.
+
+#### Completed
+- #21 Demo Mode citation/source accordions completed via PR #41.
+- Demo source-map loading hardened via PR #42.
+- #23 human-readable export context and human/AI export grouping completed via PR #43.
+
+#### Decisions
+- Keep hosted deployment prep separate from local/demo trust polish.
+- See `docs/05-decision-log.md` for related Phase 1C and deferral decisions.
+
+#### Validation
+- PR-level validation completed in PR #41, PR #42, and PR #43.
+
+#### Deferred
+- #18 Streamlit Community Cloud deployment prep.
+- #20 walkthrough video/screenshot recipe.
+
+#### Next session starter
+- Wrap Phase 1 in durable docs and make Phase 2 start with baseline benchmarking.
+
+### 2026-04-25 21:42 ET — Phase 1 wrap and Phase 2 handoff
+
+#### Goal
+- Record Phase 1 completion, intentional deferrals, and the Phase 2 baseline gate.
+
+#### Completed
+- PR #44 updated durable docs to mark Phase 1 complete.
+- Recorded #18 and #20 as intentional deferrals.
+- Set Phase 2 order to begin with baseline benchmarking before model/API/speed work.
+
+#### Decisions
+- Phase 2 must start with baseline benchmarking.
+- See `docs/05-decision-log.md` for the Phase 1C wrap decision.
+
+#### Validation
+- PR #44 validated docs-only scope and grep checks for stale Phase 1C/#18/Future CI wording.
+
+#### Deferred
+- #18 Streamlit Community Cloud deployment prep remains deferred until a hosted public demo is needed.
+- #20 walkthrough video/screenshot recipe remains deferred until after Phase 2 stabilizes.
+
+#### Next session starter
+- Start Phase 2 baseline benchmarking and current-state measurement against the demo bundle.


### PR DESCRIPTION
﻿## Summary
- Standardizes decision logging, heartbeat, memory, and session logging around concise operational history.
- Adds docs/09-session-log.md with entry format and initial Phase 1C / Phase 1 wrap sessions.
- Adds a session closeout protocol to docs/04-agent-workflow.md and a small README pointer to durable history docs.

## Files changed
- README.md
- docs/04-agent-workflow.md
- docs/05-decision-log.md
- docs/06-heartbeat.md
- docs/08-memory.md
- docs/09-session-log.md

## Validation grep results
- `git status --short`: only scoped docs files changed before commit.
- `git grep -n "Session Log" -- docs/09-session-log.md`: docs/09-session-log.md:1.
- `git grep -n "Last updated:" -- docs/06-heartbeat.md`: docs/06-heartbeat.md:3.
- `git grep -n "Revisit trigger" -- docs/05-decision-log.md`: matches entry template and decision entries.
- `git grep -n "Session closeout protocol" -- docs/04-agent-workflow.md`: docs/04-agent-workflow.md:33.
- `git diff --cached --check`: passed before commit.

## Scope
This is docs-only. No source code, tests, CI, deployment config, screenshots, archives, logs, prompts, schemas, model/API code, or backend architecture files changed.

## Phase 2
Phase 2 implementation has not started. The docs continue to require baseline benchmarking before Responses API, Structured Outputs, model swaps, prompt/schema changes, or speed refactors.
