### PR TITLE
docs: add Phase 2 baseline benchmark harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,33 @@ Under the A–G tab there is an optional **“Full policy breakdown”** section
 
 You can also run the underlying pipelines from the command line without Streamlit.
 
+### Phase 2 baseline benchmark
+
+Before starting Phase 2 model/API/speed work, run the deterministic no-API baseline:
+
+```bash
+python scripts/benchmark_phase2_baseline.py --mode demo
+```
+
+This measures loading the checked-in demo bundle, rendering the existing dispute Markdown path, and resolving demo citations. It does not measure PDF extraction, OpenAI latency, token usage, cost, or live report generation.
+
+To write metrics JSON for inspection:
+
+```bash
+python scripts/benchmark_phase2_baseline.py --mode demo --output .tmp/phase2-baseline-demo.json
+```
+
+For a live current-pipeline benchmark, provide non-sensitive local inputs and `OPENAI_API_KEY`:
+
+```bash
+python scripts/benchmark_phase2_baseline.py --mode live \
+  --policy-pdf data/raw_policies/HO3_TRUE_FL_2021.pdf \
+  --denial-text data/raw_denials/HO3_TRUE_FL_2021_denial.txt \
+  --output .tmp/phase2-baseline-live.json
+```
+
+See `benchmarks/phase2-baseline.md` for the checked-in before-state report and limitations.
+
 ### Summarize a policy PDF
 
 ```bash

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -57,6 +57,15 @@ Do not rebuild this bundle from real client claim data.
 - Run app:
   - `streamlit run frontend/app.py`
 
+- Phase 2 baseline benchmark (no API calls):
+  - `python scripts/benchmark_phase2_baseline.py --mode demo`
+
+- Phase 2 baseline benchmark with metrics JSON:
+  - `python scripts/benchmark_phase2_baseline.py --mode demo --output .tmp/phase2-baseline-demo.json`
+
+- Phase 2 live pipeline benchmark (requires `OPENAI_API_KEY` and non-sensitive local inputs):
+  - `python scripts/benchmark_phase2_baseline.py --mode live --policy-pdf data/raw_policies/HO3_TRUE_FL_2021.pdf --denial-text data/raw_denials/HO3_TRUE_FL_2021_denial.txt --output .tmp/phase2-baseline-live.json`
+
 - CLI (optional):
   - `python -m src.run_baseline_policy_summary path/to/policy.pdf`
   - `python -m src.run_denial_summary data/processed/policy.json path/to/denial.txt`

--- a/benchmarks/phase2-baseline.md
+++ b/benchmarks/phase2-baseline.md
@@ -1,0 +1,76 @@
+# Phase 2 Baseline Benchmark
+
+This is the before-state benchmark for Phase 2. It exists to record what the current Phase 1 app can measure before Responses API work, Structured Outputs, model swaps, prompt/schema changes, or speed refactors begin.
+
+## Baseline run
+
+- Date: 2026-04-25
+- Command: `python scripts/benchmark_phase2_baseline.py --mode demo`
+- Input: checked-in demo bundle:
+  - `assets/demo/demo.json`
+  - `assets/demo/demo.report.md`
+  - `assets/demo/section_text.json`
+- API calls made: no
+- Environment assumptions: local Python environment with repo dependencies installed.
+
+## What this measures
+
+- Loading the deterministic demo bundle.
+- Converting the checked-in demo dispute JSON into the existing `DisputeReport` dataclass.
+- Rendering Markdown through the existing `render_dispute_markdown` path.
+- Resolving demo citations through the existing citation-linking helper.
+- Total wall-clock runtime and per-stage wall-clock timing for those steps.
+
+## What this does not measure
+
+- PDF extraction.
+- Policy sectioning.
+- OpenAI latency.
+- Token usage.
+- Cost per claim.
+- Live denial-aware report generation.
+- Streamlit browser rendering.
+
+## Baseline result
+
+Local run on 2026-04-25 using `python scripts/benchmark_phase2_baseline.py --mode demo`:
+
+| Metric | Value |
+| --- | ---: |
+| Total wall-clock runtime | 0.0024 seconds |
+| Demo citations | 23 |
+| Linked demo citations | 23 |
+| Rendered Markdown characters | 5,895 |
+
+Stage timings from the same run:
+
+| Stage | Wall-clock seconds |
+| --- | ---: |
+| `load_demo_assets` | 0.0011 |
+| `build_dispute_report_object` | 0.0001 |
+| `render_dispute_markdown` | 0.0001 |
+| `link_demo_citations` | 0.0010 |
+
+Run environment:
+
+- Python: 3.12.3
+- Platform: Windows-11-10.0.26200-SP0
+
+## Live pipeline benchmark
+
+The same harness can run the current live pipeline when non-sensitive local inputs and `OPENAI_API_KEY` are available:
+
+```bash
+python scripts/benchmark_phase2_baseline.py --mode live \
+  --policy-pdf data/raw_policies/HO3_TRUE_FL_2021.pdf \
+  --denial-text data/raw_denials/HO3_TRUE_FL_2021_denial.txt \
+  --output .tmp/phase2-baseline-live.json
+```
+
+Live mode makes OpenAI API calls and writes the same local `data/processed` or `data/processed_safe` artifacts as the current pipeline. It is intentionally not the default because the repo should have a safe deterministic benchmark that can run without API access.
+
+## Limitations
+
+- The checked-in before-state number is the deterministic no-API benchmark, not a full model/API latency benchmark.
+- Token usage and cost are not reported because the current pipeline does not expose them outside optional W&B telemetry.
+- Future Phase 2 benchmark reports should compare against this offline baseline and, where API access is available, add a live-pipeline baseline run with the same script.

--- a/docs/06-heartbeat.md
+++ b/docs/06-heartbeat.md
@@ -1,26 +1,29 @@
 # Heartbeat
 
-Last updated: 2026-04-25 21:50 ET
+Last updated: 2026-04-25 22:19 ET
 
 ## Current Phase
 - Phase 1 is complete: Phase 1A demo polish, Phase 1B technical closeout, and Phase 1C local/demo trust polish.
-- Phase 2 model/speed refactor has not started.
+- Phase 2 baseline benchmarking has started with issue #46.
+- Phase 2 model/API/speed refactor has not started.
 
 ## Current Truth
 - PR #44 wrapped Phase 1 and handed off to Phase 2 baseline benchmarking.
+- Issue #46 adds a repeatable Phase 2 before-state benchmark harness.
+- The checked-in baseline is deterministic demo-bundle mode with no API calls.
 - #21 Demo Mode citation/source accordions are complete via PR #41.
 - Demo source-map loading hardening is complete via PR #42.
 - #23 human-readable export context and human/AI export grouping are complete via PR #43.
 - The repo remains a research prototype with AI-generated and not-legal-advice framing.
 
 ## Next Action
-- Start Phase 2 with baseline benchmarking and current-state measurement against the demo bundle.
+- Review and merge the #46 baseline benchmark harness before starting #47 or other Phase 2 implementation work.
 
 ## Deferred
 - #18 Streamlit deployment prep — deferred because hosted deployment is not needed yet and adds surface area.
 - #20 walkthrough/video recipe — deferred until after Phase 2 model/API/speed upgrades stabilize.
 
 ## Watchouts
-- Phase 2 must start with baseline benchmarking.
+- Phase 2 must start with baseline benchmarking; issue #46 is the baseline-only step.
 - Do not start Responses API, Structured Outputs, model swaps, prompt changes, schema changes, or speed refactors before the baseline exists.
 - Preserve research prototype / AI-generated / not legal advice framing.

--- a/docs/08-memory.md
+++ b/docs/08-memory.md
@@ -8,8 +8,9 @@ Durable project timeline for future Codex and Claude sessions.
 - Current branch baseline: `main`.
 - Phase 1 is complete.
 - #18 Streamlit Community Cloud deployment prep and #20 walkthrough video/screenshot recipe are intentionally deferred.
-- Phase 2 has not started.
-- Next: Phase 2 baseline benchmarking. Do not start Responses API, Structured Outputs, model swaps, prompt changes, schema changes, or speed refactors before the baseline exists.
+- Phase 2 baseline benchmarking has started with issue #46.
+- Phase 2 model/API/speed implementation has not started.
+- Next: review and merge the #46 baseline benchmark harness. Do not start Responses API, Structured Outputs, model swaps, prompt changes, schema changes, or speed refactors before the baseline exists.
 
 ## Timeline
 
@@ -22,6 +23,7 @@ Durable project timeline for future Codex and Claude sessions.
 | 2026-04-25 20:45 ET | Demo source-map loading hardened | PR #42 | Reduced fragility in deterministic demo source lookup. |
 | 2026-04-25 21:07 ET | Export context polish completed | #23 / PR #43 | Added human-readable export context and human/AI grouping. |
 | 2026-04-25 21:42 ET | Phase 1 wrapped and Phase 2 handoff recorded | PR #44 | Marked Phase 1 complete, deferred #18/#20, and required Phase 2 to start with baseline benchmarking. |
+| 2026-04-25 22:19 ET | Phase 2 baseline benchmark harness added | #46 | Created the before-state benchmark before any model/API/speed refactor work. |
 
 ## Standing Guardrails
 

--- a/docs/09-session-log.md
+++ b/docs/09-session-log.md
@@ -74,3 +74,31 @@ Track real working sessions so future AI/dev sessions can quickly understand wha
 
 #### Next session starter
 - Start Phase 2 baseline benchmarking and current-state measurement against the demo bundle.
+
+### 2026-04-25 22:19 ET - Phase 2 baseline benchmark harness
+
+#### Goal
+- Start issue #46 only by adding a repeatable before-state benchmark before model/API/speed work.
+
+#### Completed
+- Added `scripts/benchmark_phase2_baseline.py`.
+- Added `benchmarks/phase2-baseline.md`.
+- Documented rerun commands in README and RUNBOOK.
+- Updated heartbeat and memory for the baseline-only Phase 2 step.
+
+#### Decisions
+- Use deterministic demo-bundle mode as the checked-in baseline because it makes no API calls and uses tracked demo-safe inputs.
+- Keep live current-pipeline benchmarking optional because it requires `OPENAI_API_KEY` and non-sensitive local inputs.
+
+#### Validation
+- `python scripts/benchmark_phase2_baseline.py --mode demo`
+- `python scripts/benchmark_phase2_baseline.py --mode demo --output .tmp/phase2-baseline-demo.json`
+- `python -m pytest -q` - 27 passed.
+
+#### Deferred
+- Live OpenAI/API benchmark run.
+- #47 Responses API migration.
+- Structured Outputs, model swaps, prompt/schema changes, and speed refactors.
+
+#### Next session starter
+- Review and merge the #46 PR, then use the baseline before starting #47 or any other Phase 2 implementation work.

--- a/scripts/benchmark_phase2_baseline.py
+++ b/scripts/benchmark_phase2_baseline.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import sys
+import time
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.citation_linking import find_section_for_citation
+from src.report_builder import render_dispute_markdown
+from src.schemas import Angle, ConfidenceBlock, DisputeReport, Point
+
+
+DEMO_JSON_PATH = ROOT / "assets" / "demo" / "demo.json"
+DEMO_MD_PATH = ROOT / "assets" / "demo" / "demo.report.md"
+DEMO_SECTION_TEXT_PATH = ROOT / "assets" / "demo" / "section_text.json"
+
+
+def _round_seconds(seconds: float) -> float:
+    return round(seconds, 4)
+
+
+@contextmanager
+def _timed(stage_name: str, timings: List[Dict[str, Any]]) -> Iterator[None]:
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        timings.append(
+            {
+                "stage": stage_name,
+                "wall_clock_seconds": _round_seconds(time.perf_counter() - start),
+            }
+        )
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Expected JSON object at {path}")
+    return payload
+
+
+def _point_from_dict(raw: Any) -> Point:
+    if isinstance(raw, dict):
+        return Point(
+            text=str(raw.get("text", "") or "").strip(),
+            citation=(
+                str(raw.get("citation", "") or "").strip()
+                if raw.get("citation")
+                else None
+            ),
+        )
+    return Point(text=str(raw or "").strip())
+
+
+def _angle_from_dict(raw: Any) -> Angle:
+    if isinstance(raw, dict):
+        citations = [
+            str(citation).strip()
+            for citation in raw.get("citations", []) or []
+            if str(citation).strip()
+        ]
+        return Angle(text=str(raw.get("text", "") or "").strip(), citations=citations)
+    return Angle(text=str(raw or "").strip())
+
+
+def _to_dispute_report(payload: Dict[str, Any]) -> DisputeReport:
+    confidence_raw = payload.get("confidence") or {}
+    if not isinstance(confidence_raw, dict):
+        confidence_raw = {}
+
+    score = confidence_raw.get("score")
+    confidence = ConfidenceBlock(
+        score=float(score) if isinstance(score, (int, float)) else None,
+        notes=str(confidence_raw.get("notes", "") or ""),
+        verify_clauses=[
+            str(clause).strip()
+            for clause in confidence_raw.get("verify_clauses", []) or []
+            if str(clause).strip()
+        ],
+    )
+
+    return DisputeReport(
+        policy_id=str(payload.get("policy_id", "") or ""),
+        denial_id=str(payload.get("denial_id", "") or ""),
+        plain_summary=str(payload.get("plain_summary", "") or ""),
+        coverage_highlights=[
+            _point_from_dict(item)
+            for item in payload.get("coverage_highlights", []) or []
+        ],
+        exclusions_limitations=[
+            _point_from_dict(item)
+            for item in payload.get("exclusions_limitations", []) or []
+        ],
+        denial_reasons=[
+            _point_from_dict(item) for item in payload.get("denial_reasons", []) or []
+        ],
+        dispute_angles=[
+            _angle_from_dict(item) for item in payload.get("dispute_angles", []) or []
+        ],
+        missing_info=[
+            str(item).strip()
+            for item in payload.get("missing_info", []) or []
+            if str(item).strip()
+        ],
+        confidence=confidence,
+    )
+
+
+def _iter_demo_citations(report: Dict[str, Any]) -> Iterable[str]:
+    for field in ("coverage_highlights", "exclusions_limitations", "denial_reasons"):
+        for item in report.get(field, []) or []:
+            citation = str(item.get("citation", "") or "").strip()
+            if citation:
+                yield citation
+
+    for angle in report.get("dispute_angles", []) or []:
+        for citation in angle.get("citations", []) or []:
+            citation = str(citation).strip()
+            if citation:
+                yield citation
+
+
+def _environment() -> Dict[str, Any]:
+    return {
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "working_directory": str(ROOT),
+    }
+
+
+def benchmark_demo_bundle() -> Dict[str, Any]:
+    timings: List[Dict[str, Any]] = []
+    start = time.perf_counter()
+
+    with _timed("load_demo_assets", timings):
+        demo_report = _read_json(DEMO_JSON_PATH)
+        demo_markdown = DEMO_MD_PATH.read_text(encoding="utf-8")
+        section_map = _read_json(DEMO_SECTION_TEXT_PATH)
+
+    with _timed("build_dispute_report_object", timings):
+        dispute_report = _to_dispute_report(demo_report)
+
+    with _timed("render_dispute_markdown", timings):
+        rendered_markdown = render_dispute_markdown(dispute_report)
+
+    with _timed("link_demo_citations", timings):
+        citations = list(_iter_demo_citations(demo_report))
+        linked_count = sum(
+            1
+            for citation in citations
+            if find_section_for_citation(citation, section_map) is not None
+        )
+
+    total_wall_clock_seconds = _round_seconds(time.perf_counter() - start)
+
+    return {
+        "benchmark": "phase2_baseline",
+        "mode": "demo_bundle_offline",
+        "generated_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+        "api_calls_made": False,
+        "inputs": {
+            "demo_json": str(DEMO_JSON_PATH.relative_to(ROOT)),
+            "demo_markdown": str(DEMO_MD_PATH.relative_to(ROOT)),
+            "demo_section_text": str(DEMO_SECTION_TEXT_PATH.relative_to(ROOT)),
+        },
+        "environment": _environment(),
+        "total_wall_clock_seconds": total_wall_clock_seconds,
+        "stage_timings": timings,
+        "counts": {
+            "coverage_highlights": len(dispute_report.coverage_highlights),
+            "exclusions_limitations": len(dispute_report.exclusions_limitations),
+            "denial_reasons": len(dispute_report.denial_reasons),
+            "dispute_angles": len(dispute_report.dispute_angles),
+            "missing_info": len(dispute_report.missing_info),
+            "citations": len(citations),
+            "linked_citations": linked_count,
+            "demo_markdown_chars": len(demo_markdown),
+            "rendered_markdown_chars": len(rendered_markdown),
+            "section_text_entries": len(section_map),
+        },
+        "token_usage": None,
+        "cost_estimate": None,
+        "limitations": [
+            "Offline demo-bundle mode does not run PDF extraction, sectioning, OpenAI calls, or live dispute generation.",
+            "Token usage and cost are not collected because the current local pipeline does not expose them outside optional W&B telemetry.",
+        ],
+    }
+
+
+def benchmark_live_pipeline(policy_pdf: Path, denial_text_path: Path) -> Dict[str, Any]:
+    from src.demo_api import run_dispute_analysis
+    from src.run_baseline_policy_summary import summarize_policy
+
+    timings: List[Dict[str, Any]] = []
+    start = time.perf_counter()
+
+    if not policy_pdf.is_file():
+        raise FileNotFoundError(f"Policy PDF not found: {policy_pdf}")
+    if not denial_text_path.is_file():
+        raise FileNotFoundError(f"Denial text file not found: {denial_text_path}")
+
+    with _timed("policy_summary_pipeline", timings):
+        summary_json_path = summarize_policy(policy_pdf)
+
+    with _timed("load_denial_text", timings):
+        denial_text = denial_text_path.read_text(encoding="utf-8", errors="ignore")
+
+    with _timed("dispute_analysis_pipeline", timings):
+        dispute_result = run_dispute_analysis(
+            summary_json_path,
+            denial_text,
+            denial_id=denial_text_path.stem,
+        )
+
+    total_wall_clock_seconds = _round_seconds(time.perf_counter() - start)
+
+    return {
+        "benchmark": "phase2_baseline",
+        "mode": "live_pipeline",
+        "generated_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+        "api_calls_made": True,
+        "inputs": {
+            "policy_pdf": str(policy_pdf),
+            "denial_text": str(denial_text_path),
+        },
+        "environment": _environment(),
+        "total_wall_clock_seconds": total_wall_clock_seconds,
+        "stage_timings": timings,
+        "artifacts": {
+            "policy_summary_json": str(summary_json_path),
+            **(dispute_result.get("artifacts") or {}),
+        },
+        "token_usage": None,
+        "cost_estimate": None,
+        "limitations": [
+            "Live mode measures current end-to-end policy summary and dispute analysis calls, but does not change pipeline behavior.",
+            "Token usage and cost are not collected because the current local pipeline does not expose them outside optional W&B telemetry.",
+        ],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the Phase 2 before-state benchmark harness."
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("demo", "live"),
+        default="demo",
+        help="Benchmark mode. 'demo' is deterministic and makes no API calls.",
+    )
+    parser.add_argument(
+        "--policy-pdf",
+        type=Path,
+        help="Policy PDF for --mode live. Requires OPENAI_API_KEY.",
+    )
+    parser.add_argument(
+        "--denial-text",
+        type=Path,
+        help="Denial letter .txt file for --mode live. Requires OPENAI_API_KEY.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write benchmark metrics JSON.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    if args.mode == "demo":
+        result = benchmark_demo_bundle()
+    else:
+        if args.policy_pdf is None or args.denial_text is None:
+            raise SystemExit("--mode live requires --policy-pdf and --denial-text")
+        result = benchmark_live_pipeline(args.policy_pdf, args.denial_text)
+
+    rendered = json.dumps(result, indent=2, ensure_ascii=False)
+    print(rendered)
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
﻿## Summary
- Closes #46.
- Adds `scripts/benchmark_phase2_baseline.py`, a narrow Phase 2 before-state benchmark harness.
- Adds `benchmarks/phase2-baseline.md` with the checked-in no-API demo-bundle baseline result.
- Documents rerun commands in README and RUNBOOK, and updates heartbeat/memory/session log for the #46 baseline-only step.

## What the benchmark measures
- Default `--mode demo` loads the tracked demo bundle, converts `assets/demo/demo.json` into the existing `DisputeReport` dataclass, renders through the existing Markdown path, and resolves demo citations through the existing citation-linking helper.
- It records total wall-clock runtime, per-stage timing, citation counts, linked citation counts, and rendered Markdown size.

## What it intentionally does not measure
- PDF extraction, policy sectioning, OpenAI latency, token usage, cost per claim, live denial-aware report generation, Streamlit browser rendering, pipeline optimization, or model/API behavior changes.
- Token and cost metrics are left null because the current local pipeline does not expose them outside optional W&B telemetry.

## API access
- The checked-in baseline and default command do not require OpenAI/API access.
- Optional `--mode live` requires `OPENAI_API_KEY` plus non-sensitive local policy PDF and denial text inputs, and it uses existing pipeline behavior without changing prompts, schemas, models, API type, PDF processing, or execution strategy.

## How to rerun
```bash
python scripts/benchmark_phase2_baseline.py --mode demo
python scripts/benchmark_phase2_baseline.py --mode demo --output .tmp/phase2-baseline-demo.json
```

Optional live current-pipeline benchmark:
```bash
python scripts/benchmark_phase2_baseline.py --mode live \
  --policy-pdf data/raw_policies/HO3_TRUE_FL_2021.pdf \
  --denial-text data/raw_denials/HO3_TRUE_FL_2021_denial.txt \
  --output .tmp/phase2-baseline-live.json
```

## Validation performed
- `python scripts/benchmark_phase2_baseline.py --mode demo` - passed, no API calls.
- `python scripts/benchmark_phase2_baseline.py --mode demo --output .tmp/phase2-baseline-demo.json` - passed, no API calls.
- `python -m pytest -q` - 27 passed.
- `git diff --cached --check` - passed before commit.

## Scope notes
- This PR is benchmark harness plus docs/report updates only.
- Phase 2 implementation has not started: no #47 Responses API migration, Structured Outputs, prompt changes, schema changes, model swaps, parallelization, PDF processing changes, deployment config, auth, users, billing, server-side storage, or PDF export work.
