### PR TITLE
feat: add Structured Outputs schema for dispute report generation

### DIFF
--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -55,6 +55,8 @@ def call_llm_json(
     timeout: float = 30.0,
     model: Optional[str] = None,
     stage: Optional[str] = None,
+    response_schema: Optional[Dict[str, Any]] = None,
+    schema_name: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Call the LLM expecting a JSON object.
@@ -66,6 +68,17 @@ def call_llm_json(
     """
     last_raw: Optional[str] = None
     model_name = model or _get_model_name()
+    if response_schema is None:
+        text_arg = {"format": {"type": "json_object"}}
+    else:
+        text_arg = {
+            "format": {
+                "type": "json_schema",
+                "name": schema_name or stage or "structured_output",
+                "schema": response_schema,
+                "strict": True,
+            }
+        }
 
     for attempt in range(1, max_retries + 1):
         start_time = time.time()
@@ -77,7 +90,7 @@ def call_llm_json(
                 model=model_name,
                 instructions=system_prompt,
                 input=user_prompt,
-                text={"format": {"type": "json_object"}},
+                text=text_arg,
                 temperature=temperature,
                 store=False,
             )

--- a/src/summarizer_frontier.py
+++ b/src/summarizer_frontier.py
@@ -91,6 +91,92 @@ Rules:
 """
 
 
+DISPUTE_REPORT_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "plain_summary": {"type": "string"},
+        "coverage_highlights": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "citation": {"type": ["string", "null"]},
+                },
+                "required": ["text", "citation"],
+                "additionalProperties": False,
+            },
+        },
+        "exclusions_limitations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "citation": {"type": ["string", "null"]},
+                },
+                "required": ["text", "citation"],
+                "additionalProperties": False,
+            },
+        },
+        "denial_reasons": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "citation": {"type": ["string", "null"]},
+                },
+                "required": ["text", "citation"],
+                "additionalProperties": False,
+            },
+        },
+        "dispute_angles": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "citations": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+                "required": ["text", "citations"],
+                "additionalProperties": False,
+            },
+        },
+        "missing_info": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+        "confidence": {
+            "type": "object",
+            "properties": {
+                "score": {"type": ["number", "null"]},
+                "notes": {"type": "string"},
+                "verify_clauses": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+            },
+            "required": ["score", "notes", "verify_clauses"],
+            "additionalProperties": False,
+        },
+    },
+    "required": [
+        "plain_summary",
+        "coverage_highlights",
+        "exclusions_limitations",
+        "denial_reasons",
+        "dispute_angles",
+        "missing_info",
+        "confidence",
+    ],
+    "additionalProperties": False,
+}
+
+
 def _build_policy_overview_block(policy_summary_payload: Dict[str, Any]) -> str:
     """
     Compress the policy summary into a compact, LLM-friendly view:
@@ -264,6 +350,8 @@ def build_denial_aware_report(
         max_retries=3,
         timeout=60.0,
         stage="dispute_report",
+        response_schema=DISPUTE_REPORT_SCHEMA,
+        schema_name="dispute_report",
     )
 
     plain_summary = str(data.get("plain_summary", "") or "").strip()

--- a/tests/test_llm_client_structured.py
+++ b/tests/test_llm_client_structured.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, Iterable
+from unittest.mock import Mock, patch
+
+from src.llm_client import call_llm_json
+from src.schemas import DisputeReport
+from src.summarizer_frontier import (
+    DISPUTE_REPORT_SCHEMA,
+    build_denial_aware_report,
+    summarize_section,
+)
+
+
+def _settings() -> SimpleNamespace:
+    return SimpleNamespace(openai_api_key="test-key")
+
+
+def _response(output_text: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        output_text=output_text,
+        usage=SimpleNamespace(
+            input_tokens=11,
+            output_tokens=7,
+            total_tokens=18,
+        ),
+    )
+
+
+def _client_with_response(response: SimpleNamespace) -> Mock:
+    client = Mock()
+    client.responses.create.return_value = response
+    return client
+
+
+def _sample_response_schema() -> Dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {"ok": {"type": "boolean"}},
+        "required": ["ok"],
+        "additionalProperties": False,
+    }
+
+
+def _synthetic_dispute_payload() -> Dict[str, Any]:
+    return {
+        "plain_summary": "The insurer denied the claim based on stated policy terms.",
+        "coverage_highlights": [
+            {"text": "Coverage A may apply.", "citation": "COVERAGE A - DWELLING"}
+        ],
+        "exclusions_limitations": [
+            {"text": "Wear and tear may be raised.", "citation": None}
+        ],
+        "denial_reasons": [
+            {"text": "The insurer cited an exclusion.", "citation": "EXCLUSIONS"}
+        ],
+        "dispute_angles": [
+            {"text": "Check whether the cited exclusion fits.", "citations": ["EXCLUSIONS"]}
+        ],
+        "missing_info": ["Adjuster photos"],
+        "confidence": {
+            "score": 0.72,
+            "notes": "Based on summarized policy sections and denial text.",
+            "verify_clauses": ["EXCLUSIONS"],
+        },
+    }
+
+
+def test_call_llm_json_uses_json_object_when_no_schema_is_supplied() -> None:
+    client = _client_with_response(_response('{"ok": true}'))
+
+    with (
+        patch("src.llm_client.get_settings", return_value=_settings()),
+        patch("src.llm_client.OpenAI", return_value=client),
+    ):
+        result = call_llm_json(
+            system_prompt="system JSON instruction",
+            user_prompt="user JSON instruction",
+            max_retries=1,
+            model="gpt-test",
+        )
+
+    assert result == {"ok": True}
+    client.responses.create.assert_called_once()
+    assert client.responses.create.call_args.kwargs["text"] == {
+        "format": {"type": "json_object"}
+    }
+
+
+def test_call_llm_json_uses_json_schema_when_schema_is_supplied() -> None:
+    client = _client_with_response(_response('{"ok": true}'))
+    schema = _sample_response_schema()
+
+    with (
+        patch("src.llm_client.get_settings", return_value=_settings()),
+        patch("src.llm_client.OpenAI", return_value=client),
+    ):
+        result = call_llm_json(
+            system_prompt="system JSON instruction",
+            user_prompt="user JSON instruction",
+            max_retries=1,
+            model="gpt-test",
+            response_schema=schema,
+            schema_name="unit_test_schema",
+        )
+
+    assert result == {"ok": True}
+    client.responses.create.assert_called_once()
+    assert client.responses.create.call_args.kwargs["text"] == {
+        "format": {
+            "type": "json_schema",
+            "name": "unit_test_schema",
+            "schema": schema,
+            "strict": True,
+        }
+    }
+
+
+def test_call_llm_json_uses_stage_as_fallback_schema_name() -> None:
+    client = _client_with_response(_response('{"ok": true}'))
+    schema = _sample_response_schema()
+
+    with (
+        patch("src.llm_client.get_settings", return_value=_settings()),
+        patch("src.llm_client.OpenAI", return_value=client),
+    ):
+        call_llm_json(
+            system_prompt="system JSON instruction",
+            user_prompt="user JSON instruction",
+            max_retries=1,
+            stage="structured_stage",
+            response_schema=schema,
+        )
+
+    assert client.responses.create.call_args.kwargs["text"]["format"]["name"] == (
+        "structured_stage"
+    )
+
+
+def _walk_schema_nodes(schema: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+    yield schema
+
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        for child in properties.values():
+            if isinstance(child, dict):
+                yield from _walk_schema_nodes(child)
+
+    items = schema.get("items")
+    if isinstance(items, dict):
+        yield from _walk_schema_nodes(items)
+
+
+def test_dispute_report_schema_is_strict_mode_compatible() -> None:
+    banned_keywords = {
+        "format",
+        "pattern",
+        "default",
+        "minimum",
+        "maximum",
+        "minLength",
+        "maxLength",
+        "patternProperties",
+        "allOf",
+        "not",
+        "dependentRequired",
+        "dependentSchemas",
+        "if",
+        "then",
+        "else",
+    }
+
+    assert DISPUTE_REPORT_SCHEMA["type"] == "object"
+    assert "policy_id" not in DISPUTE_REPORT_SCHEMA["properties"]
+    assert "denial_id" not in DISPUTE_REPORT_SCHEMA["properties"]
+
+    for node in _walk_schema_nodes(DISPUTE_REPORT_SCHEMA):
+        assert banned_keywords.isdisjoint(node.keys())
+        if node.get("type") == "object":
+            properties = node.get("properties")
+            assert isinstance(properties, dict)
+            assert node.get("additionalProperties") is False
+            assert set(node.get("required", [])) == set(properties.keys())
+
+
+def test_build_denial_aware_report_passes_dispute_report_schema_and_parses_payload() -> None:
+    with patch(
+        "src.summarizer_frontier.call_llm_json",
+        return_value=_synthetic_dispute_payload(),
+    ) as call_mock:
+        report = build_denial_aware_report({"sections": []}, "Denied.")
+
+    call_mock.assert_called_once()
+    kwargs = call_mock.call_args.kwargs
+    assert kwargs["response_schema"] is DISPUTE_REPORT_SCHEMA
+    assert kwargs["schema_name"] == "dispute_report"
+
+    assert isinstance(report, DisputeReport)
+    assert report.plain_summary.startswith("The insurer denied")
+    assert report.coverage_highlights[0].citation == "COVERAGE A - DWELLING"
+    assert report.exclusions_limitations[0].citation is None
+    assert report.dispute_angles[0].citations == ["EXCLUSIONS"]
+    assert report.confidence.score == 0.72
+
+
+def test_summarize_section_does_not_pass_response_schema() -> None:
+    with patch(
+        "src.summarizer_frontier.call_llm_json",
+        return_value={
+            "summary_overall": "Coverage summary.",
+            "key_coverages": ["Coverage A"],
+            "key_exclusions": ["Wear and tear"],
+            "conditions_notable": ["Prompt notice"],
+            "dispute_angles_possible": ["Check ambiguity"],
+        },
+    ) as call_mock:
+        summary = summarize_section("COVERAGE A", "Policy text.")
+
+    call_mock.assert_called_once()
+    assert "response_schema" not in call_mock.call_args.kwargs
+    assert summary.section_name == "COVERAGE A"


### PR DESCRIPTION
Closes #48

## Scope summary
- Extends `call_llm_json` with optional Responses API `text.format` JSON Schema support while preserving the existing `json_object` default path.
- Adds a strict-mode `DISPUTE_REPORT_SCHEMA` for the final dispute report payload only.
- Wires Structured Outputs only into `build_denial_aware_report`.
- Adds mocked unit coverage for the wrapper branch, schema compatibility, and caller boundaries.

## Files changed
- `src/llm_client.py`
- `src/summarizer_frontier.py`
- `tests/test_llm_client_structured.py`

## Test summary
- `python -m pytest -q` -> 39 passed
- `git diff --check` -> passed
- Validation checks:
  - `json_object` appears once in `src/llm_client.py` as the fallback branch.
  - `json_schema` appears once in `src/llm_client.py` as the Structured Outputs branch.
  - `DISPUTE_REPORT_SCHEMA` is defined and used in `src/summarizer_frontier.py`.
  - `response_schema` is used only in `build_denial_aware_report`, not `summarize_section`.
- Manual live validation: ran one non-writing local dispute-report call using existing safe sample files; returned `DisputeReport` with populated A-G fields.
- Demo Mode validation: confirmed the live-analysis guard raises before `build_denial_aware_report`; API report call count stayed 0.

## Explicit boundary statement
- Section summaries unchanged.
- Prompts unchanged.
- Dataclasses unchanged.
- Parsers unchanged.
- Telemetry unchanged.
- Retry behavior unchanged.
- Model selection unchanged.
- Benchmark unchanged.
- PDF processing unchanged.

## Deferred work
- Prompt cleanup deferred.
- Section-summary Structured Outputs deferred.
- Stage-specific model config deferred to #49+.
- Benchmark comparison deferred to the final Phase 2 benchmark issue.