### PR TITLE
docs: sync Phase 2 status after issue 48

### DIFF
--- a/docs/01-current-state.md
+++ b/docs/01-current-state.md
@@ -24,6 +24,7 @@ Phase 1 is complete. The app remains a Streamlit research prototype with determi
 - PR #43: human-readable export context and human/AI export grouping.
 - PR #54: Phase 2 baseline benchmark harness and checked-in no-API baseline report.
 - PR #56: #47 Responses API migration for the single OpenAI wrapper.
+- PR #58: #48 Structured Outputs for final dispute report generation only.
 
 ## Current Phase
 
@@ -37,7 +38,9 @@ Phase 1C local/demo trust polish is complete with #21 Demo Mode citation/source 
 
 #20 walkthrough video and screenshot recipe is intentionally deferred because walkthrough/video work should wait until after Phase 2 stabilizes.
 
-Phase 2 baseline benchmarking is complete via #46 / PR #54. #47 Responses API migration is complete via PR #56. The next intended issue is #48 Structured Outputs. No Structured Outputs work, prompt/schema changes, model swaps, PDF processing changes, or speed refactors have started.
+Phase 2 baseline benchmarking is complete via #46 / PR #54. #47 Responses API migration is complete via PR #56. #48 Structured Outputs is complete via PR #58 for final dispute report generation only.
+
+Section summaries intentionally remain on the default `json_object` mode. The next intended issue is #49 stage-specific model configuration. No model swaps, prompt changes, dataclass/schema refactors, parser changes, PDF processing changes, benchmark changes, or speed refactors have started.
 
 ## Local Cleanup
 

--- a/docs/03-roadmap.md
+++ b/docs/03-roadmap.md
@@ -32,20 +32,21 @@ Intentionally deferred:
 - #18 Streamlit Community Cloud deployment prep - revisit only when a hosted public demo is needed.
 - #20 walkthrough video/screenshot recipe - revisit after Phase 2 stabilizes.
 
-## Phase 2: Model and speed refactor - Responses API migration complete
+## Phase 2: Model and speed refactor - Structured Outputs complete
 
-True Phase 2 remains reserved for model/speed/API refactor work. Baseline measurement is complete via #46 / PR #54. The Responses API migration is complete via #47 / PR #56. The next intended issue is #48 Structured Outputs.
+True Phase 2 remains reserved for model/speed/API refactor work. Baseline measurement is complete via #46 / PR #54. The Responses API migration is complete via #47 / PR #56. Structured Outputs for final dispute report generation is complete via #48 / PR #58. The next intended issue is #49 stage-specific model configuration.
 
 Gating rule:
 
-Handle #48 separately. Do not bundle model swaps, prompt rewrites, report schema changes, PDF processing changes, or speed refactors into the Structured Outputs PR.
+Handle #49 separately. Do not bundle prompt rewrites, report schema changes, PDF processing changes, benchmark changes, or speed refactors into the stage-specific model configuration PR.
 
 Order:
 
 1. Baseline benchmarking and current-state measurement: complete via #46 / PR #54.
 2. Replace the Chat Completions wrapper with the Responses API: complete via #47 / PR #56.
-3. Add Structured Outputs schemas for sectioning and dispute report generation: next via #48.
-4. Add stage-specific model configuration.
+3. Add Structured Outputs for final dispute report generation: complete via #48 / PR #58.
+   Section summaries intentionally remain on `json_object` mode.
+4. Add stage-specific model configuration: next via #49.
 5. Speed work: parallelize per-section LLM calls and remove redundant PDF reprocessing in the live pipeline.
 6. Add focused-analysis mode.
 7. Final benchmark report comparing latency, cost, and report quality against the Phase 2 baseline.

--- a/docs/06-heartbeat.md
+++ b/docs/06-heartbeat.md
@@ -1,16 +1,18 @@
 # Heartbeat
 
-Last updated: 2026-04-25 22:59 ET
+Last updated: 2026-04-25 23:19 ET
 
 ## Current Phase
 - Phase 1 is complete: Phase 1A demo polish, Phase 1B technical closeout, and Phase 1C local/demo trust polish.
 - Phase 2 baseline benchmarking is complete via #46 / PR #54.
 - Phase 2 Responses API migration is complete via #47 / PR #56.
+- Phase 2 Structured Outputs for final dispute report generation is complete via #48 / PR #58.
 
 ## Current Truth
 - PR #44 wrapped Phase 1 and handed off to Phase 2 baseline benchmarking.
 - PR #54 merged the repeatable Phase 2 before-state benchmark harness.
 - PR #56 migrated the single OpenAI wrapper to the Responses API without prompt, schema, model, retry, telemetry, PDF-processing, benchmark, or pipeline optimization changes.
+- PR #58 added Responses API Structured Outputs strict JSON Schema mode only for final dispute report generation. Section summaries intentionally remain on default `json_object` mode.
 - The checked-in baseline is deterministic demo-bundle mode with no API calls.
 - #21 Demo Mode citation/source accordions are complete via PR #41.
 - Demo source-map loading hardening is complete via PR #42.
@@ -18,7 +20,7 @@ Last updated: 2026-04-25 22:59 ET
 - The repo remains a research prototype with AI-generated and not-legal-advice framing.
 
 ## Next Action
-- Start #48 Structured Outputs only in a separate PR. Do not bundle model swaps, prompt rewrites, report schema changes, PDF processing changes, or speed refactors.
+- Start #49 stage-specific model configuration only in a separate PR. Do not bundle prompt rewrites, report schema changes, PDF processing changes, benchmark changes, or speed refactors.
 
 ## Deferred
 - #18 Streamlit deployment prep — deferred because hosted deployment is not needed yet and adds surface area.
@@ -26,6 +28,7 @@ Last updated: 2026-04-25 22:59 ET
 
 ## Watchouts
 - #46 baseline benchmarking is complete; use it as the before-state reference for remaining Phase 2 work.
-- #47 Responses API migration is complete; do not re-open API migration work while starting #48.
-- Preserve #48 scope: Structured Outputs only, with no model swaps, prompt rewrites, report schema changes, PDF processing changes, or speed refactors.
+- #47 Responses API migration is complete; do not re-open API migration work while starting #49.
+- #48 Structured Outputs is complete for final dispute report generation only; do not expand it while starting #49.
+- Section summaries remain on `json_object` mode unless a later issue explicitly changes that.
 - Preserve research prototype / AI-generated / not legal advice framing.

--- a/docs/08-memory.md
+++ b/docs/08-memory.md
@@ -10,7 +10,9 @@ Durable project timeline for future Codex and Claude sessions.
 - #18 Streamlit Community Cloud deployment prep and #20 walkthrough video/screenshot recipe are intentionally deferred.
 - Phase 2 baseline benchmarking is complete via #46 / PR #54.
 - Phase 2 Responses API migration is complete via #47 / PR #56.
-- Next: start #48 Structured Outputs only. Do not bundle model swaps, prompt rewrites, report schema changes, PDF processing changes, or speed refactors in the #48 PR.
+- Phase 2 Structured Outputs for final dispute report generation is complete via #48 / PR #58.
+- Section summaries intentionally remain on default `json_object` mode.
+- Next: start #49 stage-specific model configuration only. Do not bundle prompt rewrites, report schema changes, PDF processing changes, benchmark changes, or speed refactors in the #49 PR.
 
 ## Timeline
 
@@ -25,6 +27,7 @@ Durable project timeline for future Codex and Claude sessions.
 | 2026-04-25 21:42 ET | Phase 1 wrapped and Phase 2 handoff recorded | PR #44 | Marked Phase 1 complete, deferred #18/#20, and required Phase 2 to start with baseline benchmarking. |
 | 2026-04-25 22:25 ET | Phase 2 baseline benchmark harness merged | #46 / PR #54 | Created the before-state benchmark before any model/API/speed refactor work. |
 | 2026-04-25 22:57 ET | Responses API migration merged | #47 / PR #56 | Replaced the wrapper API surface while preserving prompts, schemas, model choices, retry behavior, telemetry names, PDF processing, benchmark harness, and pipeline behavior. |
+| 2026-04-25 23:19 ET | Structured Outputs for dispute reports merged | #48 / PR #58 | Added strict JSON Schema mode only to final dispute report generation; section summaries remain on `json_object` mode. |
 
 ## Standing Guardrails
 

--- a/docs/09-session-log.md
+++ b/docs/09-session-log.md
@@ -151,3 +151,29 @@ Track real working sessions so future AI/dev sessions can quickly understand wha
 
 #### Next session starter
 - Start #48 only: Structured Outputs, without model swaps, prompt rewrites, report schema changes, PDF processing changes, benchmark changes, or speed refactors.
+
+### 2026-04-25 23:19 ET - Post-#58 hygiene truth sync
+
+#### Goal
+- Confirm #48 / PR #58 post-merge state and align durable docs with #49 as the next intended issue.
+
+#### Completed
+- Confirmed PR #58 is merged and issue #48 is closed.
+- Confirmed #49 is open and next in the Phase 2 order.
+- Updated durable docs to mark #48 complete and #49 next.
+- Recorded that Structured Outputs were applied only to final dispute report generation.
+- Recorded that section summaries intentionally remain on default `json_object` mode.
+
+#### Decisions
+- No new technical decisions.
+
+#### Validation
+- Git/GitHub hygiene checks completed.
+- Docs-only diff reviewed.
+
+#### Deferred
+- #49 stage-specific model configuration.
+- Prompt cleanup, section-summary Structured Outputs, benchmark comparison, PDF processing changes, and speed refactors.
+
+#### Next session starter
+- Start #49 only: stage-specific model configuration, without prompt rewrites, report schema changes, PDF processing changes, benchmark changes, or speed refactors.


### PR DESCRIPTION
## Scope summary
- Marks #48 / PR #58 complete in durable Phase 2 docs.
- Records that Structured Outputs were applied only to final dispute report generation.
- Records that section summaries intentionally remain on default `json_object` mode.
- Sets #49 stage-specific model configuration as the next intended issue.

## Files changed
- `docs/01-current-state.md`
- `docs/03-roadmap.md`
- `docs/06-heartbeat.md`
- `docs/08-memory.md`
- `docs/09-session-log.md`

## Validation
- Confirmed local `main` matched `origin/main` before editing.
- Confirmed PR #58 is merged.
- Confirmed issue #48 is closed.
- Confirmed issue #49 is open.
- `git diff --check` passed.
- Changed files are docs-only.

## Boundaries
- Did not start #49.
- No model, prompt, schema/dataclass, parser, Structured Outputs implementation, PDF processing, benchmark, deployment, auth, storage, or PDF export changes.