### PR TITLE
feat: add stage-specific model configuration via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 OPENAI_API_KEY=sk-your-key-here
 OPENAI_MODEL=gpt-4.1-mini
 
+# Optional: stage-specific model overrides. When set, calls for that
+# stage use the stage-specific value. If unset or empty, OPENAI_MODEL
+# or the built-in gpt-4.1-mini default is used.
+# Convention: OPENAI_MODEL_<STAGE_UPPER>.
+# OPENAI_MODEL_SECTION_SUMMARY=
+# OPENAI_MODEL_DISPUTE_REPORT=
+
 # Hosted demo safety
 # When true, the Streamlit app is locked to deterministic Demo Mode and
 # file uploads / live analysis are disabled.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ python -m src.report_builder data/processed/
 Copy `.env.example` to `.env` and set:
 - `OPENAI_API_KEY` (required)
 - `OPENAI_MODEL` (defaults to `gpt-4.1-mini`)
+- `OPENAI_MODEL_<STAGE_UPPER>` optionally overrides `OPENAI_MODEL` for a specific stage, such as `OPENAI_MODEL_SECTION_SUMMARY` or `OPENAI_MODEL_DISPUTE_REPORT`
 - `SAFE_MODE=true` prevents raw policy text from being persisted
 - `PERSIST_RAW_TEXT=false` to strip raw text from outputs
 - `WANDB_ENABLED=true` for optional LLM call logging

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ OPENAI_API_KEY="sk-..."
 # Optional – override default model (defaults to gpt-4.1-mini)
 OPENAI_MODEL="gpt-4.1-mini"
 
+# Optional - per-stage overrides:
+# OPENAI_MODEL_SECTION_SUMMARY="gpt-4.1-mini"
+# OPENAI_MODEL_DISPUTE_REPORT="gpt-4.1-mini"
+
 # Data-handling flags
 SAFE_MODE=true          # when true, raw text is not persisted to disk
 PERSIST_RAW_TEXT=false  # only set true if you explicitly want raw text saved

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -39,11 +39,20 @@ def _log_to_wandb(metrics: Dict[str, Any]) -> None:
         wandb.log(metrics)
 
 
-def _get_model_name() -> str:
+def _get_model_name(stage: Optional[str] = None) -> str:
     """
-    Resolve the model name, allowing an OPENAI_MODEL override.
+    Resolve the model name with precedence:
+    1. OPENAI_MODEL_<STAGE_UPPER> if stage is provided and set.
+    2. OPENAI_MODEL if set.
+    3. gpt-4.1-mini default.
+
+    Empty-string env vars are treated as unset.
     """
-    return os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
+    if stage:
+        per_stage = os.getenv(f"OPENAI_MODEL_{stage.upper()}")
+        if per_stage:
+            return per_stage
+    return os.getenv("OPENAI_MODEL") or "gpt-4.1-mini"
 
 
 def call_llm_json(
@@ -67,7 +76,7 @@ def call_llm_json(
     - Logs metrics to wandb if a run is active (via wandb_telemetry.start_wandb_run).
     """
     last_raw: Optional[str] = None
-    model_name = model or _get_model_name()
+    model_name = model or _get_model_name(stage=stage)
     if response_schema is None:
         text_arg = {"format": {"type": "json_object"}}
     else:

--- a/tests/test_llm_client_stage_models.py
+++ b/tests/test_llm_client_stage_models.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from pytest import MonkeyPatch
+
+from src.llm_client import call_llm_json
+
+
+MODEL_ENV_VARS = (
+    "OPENAI_MODEL",
+    "OPENAI_MODEL_SECTION_SUMMARY",
+    "OPENAI_MODEL_DISPUTE_REPORT",
+    "OPENAI_MODEL_FOCUSED_ANALYSIS",
+    "OPENAI_MODEL_QA_STAGE",
+)
+
+
+def _settings() -> SimpleNamespace:
+    return SimpleNamespace(openai_api_key="test-key")
+
+
+def _response() -> SimpleNamespace:
+    return SimpleNamespace(
+        output_text='{"ok": true}',
+        usage=SimpleNamespace(
+            input_tokens=11,
+            output_tokens=7,
+            total_tokens=18,
+        ),
+    )
+
+
+def _clear_model_env(monkeypatch: MonkeyPatch) -> None:
+    for name in MODEL_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _model_used(*, stage: str | None = None, model: str | None = None) -> str:
+    client = Mock()
+    client.responses.create.return_value = _response()
+
+    kwargs = {
+        "system_prompt": "system JSON instruction",
+        "user_prompt": "user JSON instruction",
+        "max_retries": 1,
+    }
+    if stage is not None:
+        kwargs["stage"] = stage
+    if model is not None:
+        kwargs["model"] = model
+
+    with (
+        patch("src.llm_client.get_settings", return_value=_settings()),
+        patch("src.llm_client.OpenAI", return_value=client),
+    ):
+        call_llm_json(**kwargs)
+
+    return client.responses.create.call_args.kwargs["model"]
+
+
+def test_default_model_remains_gpt_4_1_mini_when_no_env_vars_are_set(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_model_env(monkeypatch)
+
+    assert _model_used(stage="section_summary") == "gpt-4.1-mini"
+
+
+def test_global_openai_model_still_works_for_known_stages(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-global")
+
+    assert _model_used(stage="section_summary") == "gpt-global"
+
+
+def test_section_summary_stage_model_wins_over_global(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-global")
+    monkeypatch.setenv("OPENAI_MODEL_SECTION_SUMMARY", "gpt-section")
+
+    assert _model_used(stage="section_summary") == "gpt-section"
+
+
+def test_dispute_report_stage_model_wins_over_global(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-global")
+    monkeypatch.setenv("OPENAI_MODEL_DISPUTE_REPORT", "gpt-dispute")
+
+    assert _model_used(stage="dispute_report") == "gpt-dispute"
+
+
+def test_explicit_model_argument_wins_over_all_env_vars(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-global")
+    monkeypatch.setenv("OPENAI_MODEL_SECTION_SUMMARY", "gpt-section")
+
+    assert _model_used(stage="section_summary", model="gpt-explicit") == "gpt-explicit"
+
+
+def test_section_summary_override_does_not_affect_dispute_report_stage(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-global")
+    monkeypatch.setenv("OPENAI_MODEL_SECTION_SUMMARY", "gpt-section")
+
+    assert _model_used(stage="dispute_report") == "gpt-global"
+
+
+def test_empty_string_stage_env_var_is_treated_as_unset(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-global")
+    monkeypatch.setenv("OPENAI_MODEL_SECTION_SUMMARY", "")
+
+    assert _model_used(stage="section_summary") == "gpt-global"
+
+
+def test_unknown_stage_falls_back_to_global_model(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-global")
+
+    assert _model_used(stage="unknown_stage") == "gpt-global"
+
+
+def test_stage_none_falls_back_to_global_model(monkeypatch: MonkeyPatch) -> None:
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-global")
+
+    assert _model_used(stage=None) == "gpt-global"
+
+
+def test_stage_lookup_is_mechanical_via_uppercasing(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-global")
+    monkeypatch.setenv("OPENAI_MODEL_QA_STAGE", "gpt-qa")
+
+    assert _model_used(stage="qa_stage") == "gpt-qa"
+
+
+def test_future_stage_env_var_works(monkeypatch: MonkeyPatch) -> None:
+    _clear_model_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-global")
+    monkeypatch.setenv("OPENAI_MODEL_FOCUSED_ANALYSIS", "gpt-focused")
+
+    assert _model_used(stage="focused_analysis") == "gpt-focused"


### PR DESCRIPTION
## Summary

Fixes #49.

Adds configuration-only per-stage model overrides using the `OPENAI_MODEL_<STAGE_UPPER>` environment variable convention while preserving the current default behavior when no per-stage override is set.

## Resolution order

1. Explicit `model=` argument passed to `call_llm_json`.
2. `OPENAI_MODEL_<STAGE_UPPER>` when `stage` is provided and the env var is non-empty.
3. `OPENAI_MODEL` when non-empty.
4. Built-in default `gpt-4.1-mini`.

Examples:

- `stage="section_summary"` checks `OPENAI_MODEL_SECTION_SUMMARY`.
- `stage="dispute_report"` checks `OPENAI_MODEL_DISPUTE_REPORT`.

## Files changed

- `src/llm_client.py`: resolves optional per-stage model env vars before falling back to `OPENAI_MODEL` / default.
- `.env.example`: documents the optional stage override convention.
- `README.md`: adds a brief advanced per-stage override note.
- `CLAUDE.md`: adds the same environment setup guidance.
- `tests/test_llm_client_stage_models.py`: covers model resolution precedence and fallback behavior.

## Tests

- `python -m pytest -q` -> 50 passed

Additional validation:

- `_get_model_name` has one definition and one call site.
- Stage override docs are present in `.env.example`, `README.md`, and `CLAUDE.md`.
- No `stage_models`, `StageModels`, or `MODEL_BY_STAGE` mapping was added under `src/`.
- `src/config.py` was not changed; `Settings.openai_model` remains unchanged.

Manual validation:

- Demo Mode was not run.
- Live API validation was not run.

## Boundaries

- No Settings refactor.
- No Stage enum.
- No prompts changed.
- No schemas changed.
- No Structured Outputs changes.
- No telemetry changes.
- No retry changes.
- No benchmark changes.
- No model tuning by default.

Post-merge durable docs sync will happen separately.