### PR TITLE
feat: parallelize section summary calls with bounded concurrency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,11 @@ OPENAI_MODEL=gpt-4.1-mini
 # OPENAI_MODEL_SECTION_SUMMARY=
 # OPENAI_MODEL_DISPUTE_REPORT=
 
+# Section summary pipeline concurrency. Each section is one LLM call.
+# Default is 4. Set to 1 to force sequential behavior.
+# Higher values may reduce latency but increase peak API request concurrency.
+# SECTION_SUMMARY_MAX_WORKERS=4
+
 # Hosted demo safety
 # When true, the Streamlit app is locked to deterministic Demo Mode and
 # file uploads / live analysis are disabled.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ Copy `.env.example` to `.env` and set:
 - `OPENAI_API_KEY` (required)
 - `OPENAI_MODEL` (defaults to `gpt-4.1-mini`)
 - `OPENAI_MODEL_<STAGE_UPPER>` optionally overrides `OPENAI_MODEL` for a specific stage, such as `OPENAI_MODEL_SECTION_SUMMARY` or `OPENAI_MODEL_DISPUTE_REPORT`
+- `SECTION_SUMMARY_MAX_WORKERS` optional; default 4. Bounds parallel section-summary LLM calls. Set to 1 to force sequential behavior.
 - `SAFE_MODE=true` prevents raw policy text from being persisted
 - `PERSIST_RAW_TEXT=false` to strip raw text from outputs
 - `WANDB_ENABLED=true` for optional LLM call logging

--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ OPENAI_MODEL="gpt-4.1-mini"
 # OPENAI_MODEL_SECTION_SUMMARY="gpt-4.1-mini"
 # OPENAI_MODEL_DISPUTE_REPORT="gpt-4.1-mini"
 
+# Optional - section summary parallelism
+# Default is 4; set to 1 for sequential behavior.
+# SECTION_SUMMARY_MAX_WORKERS=4
+
 # Data-handling flags
 SAFE_MODE=true          # when true, raw text is not persisted to disk
 PERSIST_RAW_TEXT=false  # only set true if you explicitly want raw text saved

--- a/src/run_baseline_policy_summary.py
+++ b/src/run_baseline_policy_summary.py
@@ -1,4 +1,6 @@
 import json
+import os
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Iterable, List, Dict
 
@@ -98,6 +100,23 @@ except ImportError:
 
 DATA_PROCESSED_DIR = Path("data/processed")
 SAFE_DATA_PROCESSED_DIR = Path("data/processed_safe")
+DEFAULT_SECTION_SUMMARY_WORKERS = 4
+
+
+def _resolve_section_summary_workers() -> int:
+    raw = os.getenv("SECTION_SUMMARY_MAX_WORKERS")
+    if raw is None or raw == "":
+        return DEFAULT_SECTION_SUMMARY_WORKERS
+
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_SECTION_SUMMARY_WORKERS
+
+    if value <= 0:
+        return DEFAULT_SECTION_SUMMARY_WORKERS
+
+    return value
 
 
 def _resolve_output_dir() -> Path:
@@ -127,11 +146,12 @@ def summarize_policy(pdf_path: Path) -> Path:
 
     settings = get_settings()
     persist_raw_text = settings.persist_raw_text
+    max_workers = _resolve_section_summary_workers()
     output_dir = _resolve_output_dir()
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    results: List[dict] = []
-    for section_name, section_text in sections.items():
+    def summarize_section_item(item: tuple[str, str]) -> dict:
+        section_name, section_text = item
         print(f"Summarizing section: [cyan]{section_name}[/cyan]")
 
         section_summary: SectionSummary = summarize_section(
@@ -147,7 +167,12 @@ def summarize_policy(pdf_path: Path) -> Path:
         section_dict["section_role"] = classify_section_role(
             section_name, section_text
         )
-        results.append(section_dict)
+        return section_dict
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        results: List[dict] = list(
+            executor.map(summarize_section_item, sections.items())
+        )
 
     out_path = output_dir / f"{pdf_path.stem}.json"
 

--- a/tests/test_section_summary_concurrency.py
+++ b/tests/test_section_summary_concurrency.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from src import run_baseline_policy_summary as policy_summary
+
+
+class FakeSectionSummary:
+    def __init__(self, section_name: str) -> None:
+        self.section_name = section_name
+
+    def to_dict(self) -> dict:
+        return {"section_name": self.section_name}
+
+
+def _run_summarize_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    sections: dict[str, str],
+    *,
+    persist_raw_text: bool = False,
+    summarize_section: Mock | None = None,
+) -> dict:
+    output_dir = tmp_path / "processed"
+    monkeypatch.setattr(policy_summary, "DATA_PROCESSED_DIR", output_dir)
+    monkeypatch.setattr(policy_summary, "SAFE_DATA_PROCESSED_DIR", tmp_path / "safe")
+    monkeypatch.setattr(
+        policy_summary,
+        "get_settings",
+        lambda: SimpleNamespace(persist_raw_text=persist_raw_text, safe_mode=False),
+    )
+    monkeypatch.setattr(policy_summary, "load_pdf_text", lambda pdf_path: "policy text")
+    monkeypatch.setattr(policy_summary, "split_into_sections", lambda text: sections)
+
+    if summarize_section is None:
+        summarize_section = Mock(
+            side_effect=lambda section_name, section_text: FakeSectionSummary(
+                section_name
+            )
+        )
+    monkeypatch.setattr(policy_summary, "summarize_section", summarize_section)
+
+    out_path = policy_summary.summarize_policy(tmp_path / "policy.pdf")
+
+    return json.loads(out_path.read_text(encoding="utf-8"))
+
+
+def test_summarize_policy_preserves_section_order_with_default_concurrency(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("SECTION_SUMMARY_MAX_WORKERS", raising=False)
+    sections = {
+        "FIRST": "first text",
+        "SECOND": "second text",
+        "THIRD": "third text",
+    }
+    delays = {"FIRST": 0.03, "SECOND": 0.02, "THIRD": 0.01}
+
+    def summarize(section_name: str, section_text: str) -> FakeSectionSummary:
+        time.sleep(delays[section_name])
+        return FakeSectionSummary(section_name)
+
+    payload = _run_summarize_policy(
+        monkeypatch,
+        tmp_path,
+        sections,
+        summarize_section=Mock(side_effect=summarize),
+    )
+
+    assert [section["section_name"] for section in payload["sections"]] == [
+        "FIRST",
+        "SECOND",
+        "THIRD",
+    ]
+
+
+def test_summarize_policy_preserves_section_order_with_env_concurrency(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("SECTION_SUMMARY_MAX_WORKERS", "8")
+    sections = {
+        "SECTION 0": "text 0",
+        "SECTION 1": "text 1",
+        "SECTION 2": "text 2",
+        "SECTION 3": "text 3",
+    }
+    delays = {
+        section_name: (len(sections) - index) * 0.01
+        for index, section_name in enumerate(sections)
+    }
+
+    def summarize(section_name: str, section_text: str) -> FakeSectionSummary:
+        time.sleep(delays[section_name])
+        return FakeSectionSummary(section_name)
+
+    payload = _run_summarize_policy(
+        monkeypatch,
+        tmp_path,
+        sections,
+        summarize_section=Mock(side_effect=summarize),
+    )
+
+    assert [section["section_name"] for section in payload["sections"]] == list(
+        sections
+    )
+
+
+def test_section_summary_max_workers_one_runs_sequentially(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("SECTION_SUMMARY_MAX_WORKERS", "1")
+    sections = {
+        "FIRST": "first text",
+        "SECOND": "second text",
+        "THIRD": "third text",
+    }
+    lock = threading.Lock()
+    in_flight = 0
+    peak_in_flight = 0
+
+    def summarize(section_name: str, section_text: str) -> FakeSectionSummary:
+        nonlocal in_flight, peak_in_flight
+        with lock:
+            in_flight += 1
+            peak_in_flight = max(peak_in_flight, in_flight)
+        time.sleep(0.01)
+        with lock:
+            in_flight -= 1
+        return FakeSectionSummary(section_name)
+
+    _run_summarize_policy(
+        monkeypatch,
+        tmp_path,
+        sections,
+        summarize_section=Mock(side_effect=summarize),
+    )
+
+    assert peak_in_flight <= 1
+
+
+def test_summarize_section_is_invoked_once_per_section(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("SECTION_SUMMARY_MAX_WORKERS", raising=False)
+    sections = {"A": "a text", "B": "b text", "C": "c text"}
+    summarize_section = Mock(
+        side_effect=lambda section_name, section_text: FakeSectionSummary(section_name)
+    )
+
+    _run_summarize_policy(
+        monkeypatch,
+        tmp_path,
+        sections,
+        summarize_section=summarize_section,
+    )
+
+    assert summarize_section.call_count == len(sections)
+
+
+def test_section_summary_exception_propagates_and_writes_no_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("SECTION_SUMMARY_MAX_WORKERS", raising=False)
+    sections = {"A": "a text", "B": "b text"}
+    output_dir = tmp_path / "processed"
+
+    def summarize(section_name: str, section_text: str) -> FakeSectionSummary:
+        if section_name == "B":
+            raise RuntimeError("section failed")
+        return FakeSectionSummary(section_name)
+
+    with pytest.raises(RuntimeError, match="section failed"):
+        _run_summarize_policy(
+            monkeypatch,
+            tmp_path,
+            sections,
+            summarize_section=Mock(side_effect=summarize),
+        )
+
+    assert not (output_dir / "policy.json").exists()
+
+
+def test_section_role_classification_is_preserved(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sections = {
+        "UNKNOWN": "This is only a sample policy and not an actual policy.",
+        "COVERAGE A": "We cover the dwelling on the residence premises.",
+    }
+
+    payload = _run_summarize_policy(monkeypatch, tmp_path, sections)
+
+    assert [section["section_role"] for section in payload["sections"]] == [
+        "meta",
+        "substantive",
+    ]
+
+
+def test_persist_raw_text_true_includes_raw_text(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sections = {"COVERAGE A": "covered dwelling text"}
+
+    payload = _run_summarize_policy(
+        monkeypatch,
+        tmp_path,
+        sections,
+        persist_raw_text=True,
+    )
+
+    assert payload["sections"][0]["raw_text"] == "covered dwelling text"
+
+
+def test_persist_raw_text_false_omits_raw_text(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sections = {"COVERAGE A": "covered dwelling text"}
+
+    payload = _run_summarize_policy(
+        monkeypatch,
+        tmp_path,
+        sections,
+        persist_raw_text=False,
+    )
+
+    assert "raw_text" not in payload["sections"][0]
+
+
+def test_resolve_section_summary_workers_defaults_to_four_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SECTION_SUMMARY_MAX_WORKERS", raising=False)
+
+    assert policy_summary._resolve_section_summary_workers() == 4
+
+
+def test_resolve_section_summary_workers_uses_positive_env_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SECTION_SUMMARY_MAX_WORKERS", "8")
+
+    assert policy_summary._resolve_section_summary_workers() == 8
+
+
+@pytest.mark.parametrize("value", ["not-an-int", "4.5"])
+def test_resolve_section_summary_workers_invalid_value_falls_back_to_four(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("SECTION_SUMMARY_MAX_WORKERS", value)
+
+    assert policy_summary._resolve_section_summary_workers() == 4
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_resolve_section_summary_workers_zero_or_negative_falls_back_to_four(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("SECTION_SUMMARY_MAX_WORKERS", value)
+
+    assert policy_summary._resolve_section_summary_workers() == 4
+
+
+def test_resolve_section_summary_workers_empty_string_falls_back_to_four(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SECTION_SUMMARY_MAX_WORKERS", "")
+
+    assert policy_summary._resolve_section_summary_workers() == 4
+
+
+def test_empty_sections_produce_empty_sections_list(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    payload = _run_summarize_policy(monkeypatch, tmp_path, {})
+
+    assert payload["sections"] == []
+
+
+def test_single_section_still_works(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    payload = _run_summarize_policy(
+        monkeypatch,
+        tmp_path,
+        {"COVERAGE A": "covered dwelling text"},
+    )
+
+    assert [section["section_name"] for section in payload["sections"]] == [
+        "COVERAGE A"
+    ]


### PR DESCRIPTION
## Summary

Closes #50.

Adds bounded concurrency to the section-summary loop in `summarize_policy` using `ThreadPoolExecutor`, while preserving the order produced by `sections.items()` via ordering-preserving `executor.map` collection.

## Design

- Default workers = 4.
- `SECTION_SUMMARY_MAX_WORKERS` controls section-summary LLM concurrency.
- `SECTION_SUMMARY_MAX_WORKERS=1` is a sequential kill-switch.
- Invalid, empty, unset, zero, or negative values fall back to 4.
- Exceptions from section summarization propagate, so partial JSON is not written on failure.

## Files changed

- `src/run_baseline_policy_summary.py`
- `.env.example`
- `README.md`
- `CLAUDE.md`
- `tests/test_section_summary_concurrency.py`

## Test summary

- `python -m pytest -q` -> 67 passed
- `git diff --check` -> passed
- Confirmed changed files are limited to the requested files.
- Confirmed `ThreadPoolExecutor` is introduced only in `src/run_baseline_policy_summary.py`.
- Confirmed no `asyncio` or `AsyncOpenAI` additions in touched files.
- Confirmed excluded files such as telemetry, config, frontend, and benchmark scripts are untouched.

Manual validation was not run: demo/live flows were not exercised in this session.

## Boundaries

- no PDF processing changes
- no prompts changed
- no schemas changed
- no Structured Outputs changes
- no model defaults changed
- no telemetry changes
- no retry changes
- no frontend changes
- no benchmark changes

## Deferred work

- PDF reprocessing cleanup deferred to #51
- focused-analysis mode deferred to #52
- final benchmark comparison deferred to #53