### PR TITLE
docs: sync post-issue-50 status

### DIFF
--- a/docs/01-current-state.md
+++ b/docs/01-current-state.md
@@ -26,6 +26,7 @@ Phase 1 is complete. The app remains a Streamlit research prototype with determi
 - PR #56: #47 Responses API migration for the single OpenAI wrapper.
 - PR #58: #48 Structured Outputs for final dispute report generation only.
 - PR #60: #49 stage-specific model configuration via `OPENAI_MODEL_<STAGE_UPPER>`.
+- PR #62: #50 bounded concurrency for section-summary LLM calls.
 
 ## Current Phase
 
@@ -39,11 +40,13 @@ Phase 1C local/demo trust polish is complete with #21 Demo Mode citation/source 
 
 #20 walkthrough video and screenshot recipe is intentionally deferred because walkthrough/video work should wait until after Phase 2 stabilizes.
 
-Phase 2 baseline benchmarking is complete via #46 / PR #54. #47 Responses API migration is complete via PR #56. #48 Structured Outputs is complete via PR #58 for final dispute report generation only. #49 stage-specific model configuration is complete via PR #60.
+Phase 2 baseline benchmarking is complete via #46 / PR #54. #47 Responses API migration is complete via PR #56. #48 Structured Outputs is complete via PR #58 for final dispute report generation only. #49 stage-specific model configuration is complete via PR #60. #50 section-summary latency reduction is complete via PR #62.
 
 Stage-specific model overrides are available through `OPENAI_MODEL_<STAGE_UPPER>`, such as `OPENAI_MODEL_SECTION_SUMMARY` and `OPENAI_MODEL_DISPUTE_REPORT`. Default model behavior is unchanged unless a per-stage override is explicitly set.
 
-Section summaries intentionally remain on the default `json_object` mode. The next intended issue is #50 latency reduction in the section summary pipeline. No model swaps, prompt changes, dataclass/schema refactors, parser changes, PDF processing changes, benchmark changes, or speed refactors beyond #50 have started.
+Section summaries intentionally remain on the default `json_object` mode. Section-summary calls now use bounded concurrency via `ThreadPoolExecutor`; `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior.
+
+The next intended issue is #51 redundant PDF reprocessing cleanup in the live pipeline. PDF reprocessing cleanup remains deferred to #51; no PDF processing changes, model swaps, prompt changes, dataclass/schema refactors, parser changes, benchmark changes, or speed refactors beyond #50 have started.
 
 ## Local Cleanup
 

--- a/docs/03-roadmap.md
+++ b/docs/03-roadmap.md
@@ -32,13 +32,13 @@ Intentionally deferred:
 - #18 Streamlit Community Cloud deployment prep - revisit only when a hosted public demo is needed.
 - #20 walkthrough video/screenshot recipe - revisit after Phase 2 stabilizes.
 
-## Phase 2: Model and speed refactor - Stage model config complete
+## Phase 2: Model and speed refactor - section summary concurrency complete
 
-True Phase 2 remains reserved for model/speed/API refactor work. Baseline measurement is complete via #46 / PR #54. The Responses API migration is complete via #47 / PR #56. Structured Outputs for final dispute report generation is complete via #48 / PR #58. Stage-specific model configuration is complete via #49 / PR #60. The next intended issue is #50 latency reduction in the section summary pipeline.
+True Phase 2 remains reserved for model/speed/API refactor work. Baseline measurement is complete via #46 / PR #54. The Responses API migration is complete via #47 / PR #56. Structured Outputs for final dispute report generation is complete via #48 / PR #58. Stage-specific model configuration is complete via #49 / PR #60. Section-summary latency reduction is complete via #50 / PR #62. The next intended issue is #51 redundant PDF reprocessing cleanup in the live pipeline.
 
 Gating rule:
 
-#49 added configuration flexibility only through `OPENAI_MODEL_<STAGE_UPPER>` and preserved default model behavior unless per-stage overrides are explicitly set. Handle #50 separately. Do not bundle prompt rewrites, report schema changes, PDF processing changes, benchmark changes, model swaps, or unrelated refactors into the latency-reduction PR.
+#50 added bounded concurrency for section-summary LLM calls only. Section-summary calls now use `ThreadPoolExecutor`; `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior. PDF reprocessing cleanup remains deferred to #51. Do not bundle prompt rewrites, report schema changes, benchmark changes, model swaps, or unrelated refactors into the PDF reprocessing cleanup PR.
 
 Order:
 
@@ -47,9 +47,10 @@ Order:
 3. Add Structured Outputs for final dispute report generation: complete via #48 / PR #58.
    Section summaries intentionally remain on `json_object` mode.
 4. Add stage-specific model configuration: complete via #49 / PR #60.
-5. Speed work: parallelize per-section LLM calls and remove redundant PDF reprocessing in the live pipeline: next via #50.
-6. Add focused-analysis mode.
-7. Final benchmark report comparing latency, cost, and report quality against the Phase 2 baseline.
+5. Parallelize per-section LLM calls: complete via #50 / PR #62.
+6. Remove redundant PDF reprocessing in the live pipeline: next via #51.
+7. Add focused-analysis mode.
+8. Final benchmark report comparing latency, cost, and report quality against the Phase 2 baseline.
 
 ## Out of scope across all phases
 

--- a/docs/06-heartbeat.md
+++ b/docs/06-heartbeat.md
@@ -1,6 +1,6 @@
 # Heartbeat
 
-Last updated: 2026-04-25 23:38 ET
+Last updated: 2026-04-25 23:59 ET
 
 ## Current Phase
 - Phase 1 is complete: Phase 1A demo polish, Phase 1B technical closeout, and Phase 1C local/demo trust polish.
@@ -8,6 +8,7 @@ Last updated: 2026-04-25 23:38 ET
 - Phase 2 Responses API migration is complete via #47 / PR #56.
 - Phase 2 Structured Outputs for final dispute report generation is complete via #48 / PR #58.
 - Phase 2 stage-specific model configuration is complete via #49 / PR #60.
+- Phase 2 section-summary latency reduction is complete via #50 / PR #62.
 
 ## Current Truth
 - PR #44 wrapped Phase 1 and handed off to Phase 2 baseline benchmarking.
@@ -15,6 +16,7 @@ Last updated: 2026-04-25 23:38 ET
 - PR #56 migrated the single OpenAI wrapper to the Responses API without prompt, schema, model, retry, telemetry, PDF-processing, benchmark, or pipeline optimization changes.
 - PR #58 added Responses API Structured Outputs strict JSON Schema mode only for final dispute report generation. Section summaries intentionally remain on default `json_object` mode.
 - PR #60 added optional stage-specific model overrides through `OPENAI_MODEL_<STAGE_UPPER>`, while preserving default model behavior unless per-stage overrides are explicitly set.
+- PR #62 added bounded concurrency for section-summary LLM calls using `ThreadPoolExecutor`. `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior.
 - The checked-in baseline is deterministic demo-bundle mode with no API calls.
 - #21 Demo Mode citation/source accordions are complete via PR #41.
 - Demo source-map loading hardening is complete via PR #42.
@@ -22,7 +24,7 @@ Last updated: 2026-04-25 23:38 ET
 - The repo remains a research prototype with AI-generated and not-legal-advice framing.
 
 ## Next Action
-- Start #50 latency reduction in the section summary pipeline only. Do not bundle prompt rewrites, report schema changes, PDF processing changes, benchmark changes, model swaps, or unrelated refactors.
+- Start #51 redundant PDF reprocessing cleanup in the live pipeline only. PDF reprocessing cleanup remains deferred to #51; do not bundle prompt rewrites, report schema changes, benchmark changes, model swaps, telemetry changes, frontend behavior changes, or unrelated refactors.
 
 ## Deferred
 - #18 Streamlit deployment prep — deferred because hosted deployment is not needed yet and adds surface area.
@@ -30,8 +32,10 @@ Last updated: 2026-04-25 23:38 ET
 
 ## Watchouts
 - #46 baseline benchmarking is complete; use it as the before-state reference for remaining Phase 2 work.
-- #47 Responses API migration is complete; do not re-open API migration work while starting #50.
-- #48 Structured Outputs is complete for final dispute report generation only; do not expand it while starting #50.
-- #49 stage-specific model configuration is complete; do not tune model choices by default while starting #50.
+- #47 Responses API migration is complete; do not re-open API migration work while starting #51.
+- #48 Structured Outputs is complete for final dispute report generation only; do not expand it while starting #51.
+- #49 stage-specific model configuration is complete; do not tune model choices by default while starting #51.
+- #50 section-summary concurrency is complete; do not rework prompts, schemas, model configuration, retry behavior, telemetry, or benchmark code while starting #51.
 - Section summaries remain on `json_object` mode unless a later issue explicitly changes that.
+- Section-summary calls use bounded `ThreadPoolExecutor` concurrency; keep `SECTION_SUMMARY_MAX_WORKERS=1` as the sequential kill-switch.
 - Preserve research prototype / AI-generated / not legal advice framing.

--- a/docs/08-memory.md
+++ b/docs/08-memory.md
@@ -12,9 +12,11 @@ Durable project timeline for future Codex and Claude sessions.
 - Phase 2 Responses API migration is complete via #47 / PR #56.
 - Phase 2 Structured Outputs for final dispute report generation is complete via #48 / PR #58.
 - Phase 2 stage-specific model configuration is complete via #49 / PR #60.
+- Phase 2 section-summary latency reduction is complete via #50 / PR #62.
 - Stage-specific model overrides use `OPENAI_MODEL_<STAGE_UPPER>` and default model behavior is unchanged unless a per-stage override is explicitly set.
 - Section summaries intentionally remain on default `json_object` mode.
-- Next: start #50 latency reduction in the section summary pipeline only. Do not bundle prompt rewrites, report schema changes, PDF processing changes, benchmark changes, model swaps, or unrelated refactors in the #50 PR.
+- Section-summary calls now use bounded concurrency via `ThreadPoolExecutor`. `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior.
+- Next: start #51 redundant PDF reprocessing cleanup in the live pipeline only. PDF reprocessing cleanup remains deferred to #51. Do not bundle prompt rewrites, report schema changes, benchmark changes, model swaps, telemetry changes, frontend behavior changes, or unrelated refactors in the #51 PR.
 
 ## Timeline
 
@@ -31,6 +33,7 @@ Durable project timeline for future Codex and Claude sessions.
 | 2026-04-25 22:57 ET | Responses API migration merged | #47 / PR #56 | Replaced the wrapper API surface while preserving prompts, schemas, model choices, retry behavior, telemetry names, PDF processing, benchmark harness, and pipeline behavior. |
 | 2026-04-25 23:19 ET | Structured Outputs for dispute reports merged | #48 / PR #58 | Added strict JSON Schema mode only to final dispute report generation; section summaries remain on `json_object` mode. |
 | 2026-04-25 23:37 ET | Stage-specific model configuration merged | #49 / PR #60 | Added optional `OPENAI_MODEL_<STAGE_UPPER>` overrides while preserving default model behavior unless explicitly configured. |
+| 2026-04-25 23:58 ET | Section-summary concurrency merged | #50 / PR #62 | Added bounded `ThreadPoolExecutor` concurrency for section-summary LLM calls; `SECTION_SUMMARY_MAX_WORKERS=1` remains the sequential kill-switch. |
 
 ## Standing Guardrails
 

--- a/docs/09-session-log.md
+++ b/docs/09-session-log.md
@@ -203,3 +203,29 @@ Track real working sessions so future AI/dev sessions can quickly understand wha
 
 #### Next session starter
 - Start #50 only: latency reduction in the section summary pipeline, without prompt rewrites, report schema changes, PDF processing changes, benchmark changes, model swaps, or unrelated refactors.
+
+### 2026-04-25 23:59 ET - Post-#62 hygiene truth sync
+
+#### Goal
+- Confirm #50 / PR #62 post-merge state and align durable docs with #51 as the next intended issue.
+
+#### Completed
+- Confirmed PR #62 is merged and issue #50 is closed.
+- Confirmed #51 is open and next in the Phase 2 order.
+- Updated durable docs to mark #50 complete and #51 next.
+- Recorded that section-summary calls now use bounded concurrency via `ThreadPoolExecutor`.
+- Recorded that `SECTION_SUMMARY_MAX_WORKERS` defaults to 4 and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior.
+
+#### Decisions
+- No new technical decisions.
+
+#### Validation
+- Git/GitHub hygiene checks completed.
+- Docs-only diff reviewed.
+
+#### Deferred
+- #51 redundant PDF reprocessing cleanup remains deferred to the next issue.
+- Prompt rewrites, report schema changes, Structured Outputs changes, model configuration changes, retry changes, telemetry changes, benchmark changes, frontend behavior changes, and deployment/auth/storage/PDF export work remain out of scope.
+
+#### Next session starter
+- Start #51 only: remove redundant PDF reprocessing from the live pipeline, without prompt rewrites, report schema changes, Structured Outputs changes, model configuration changes, retry changes, telemetry changes, benchmark changes, frontend behavior changes, or unrelated refactors.


### PR DESCRIPTION
## Summary

Post-merge docs truth-sync after #50 / PR #62.

Updates durable project docs to record that:

- PR #62 is merged and issue #50 is complete.
- Section-summary calls now use bounded concurrency via `ThreadPoolExecutor`.
- `SECTION_SUMMARY_MAX_WORKERS` defaults to 4.
- `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior.
- #51 is the next intended Phase 2 issue.
- PDF reprocessing cleanup remains deferred to #51.

## Scope

Docs-only. No code, prompts, schemas/dataclasses, Structured Outputs behavior, model configuration, retry behavior, telemetry semantics, benchmark code, PDF processing, frontend behavior, or deployment/auth/storage/PDF export changes.

## Files changed

- `docs/01-current-state.md`
- `docs/03-roadmap.md`
- `docs/06-heartbeat.md`
- `docs/08-memory.md`
- `docs/09-session-log.md`

`docs/05-decision-log.md` was inspected and did not need an update.

## Verification

- Local `main` confirmed up to date with `origin/main` at `bfd9adf9ce9de656455bc7f48de7cd63f105cbe4` before branching.
- PR #62 confirmed merged.
- Issue #50 confirmed closed.
- Issue #51 confirmed open and next.
- `git diff --check` passed.
- Changed files confirmed docs-only.