### PR TITLE
perf: remove redundant PDF reprocessing in live pipeline

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1040,6 +1040,9 @@ def _render_intake_form() -> None:
         "denial_filename": denial_file.name,
     }
 
+    policy_result_for_persistence = dict(policy_result)
+    policy_result_for_persistence.pop("section_text_map", None)
+
     # Save to database
     try:
         claim_id = save_claim(
@@ -1048,7 +1051,7 @@ def _render_intake_form() -> None:
             policy_filename=policy_file.name,
             denial_filename=denial_file.name,
             report_json={
-                "policy_result": policy_result,
+                "policy_result": policy_result_for_persistence,
                 "dispute_result": dispute_result,
             },
         )

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -22,7 +22,6 @@ summarizer_frontier = importlib.import_module("src.summarizer_frontier")
 report_builder = importlib.import_module("src.report_builder")
 schemas = importlib.import_module("src.schemas")
 database = importlib.import_module("src.database")
-sectioning = importlib.import_module("src.sectioning")
 citation_linking = importlib.import_module("src.citation_linking")
 
 is_demo_force_on = config.is_demo_force_on
@@ -39,8 +38,6 @@ save_claim = database.save_claim
 get_all_claims = database.get_all_claims
 get_claim_by_id = database.get_claim_by_id
 delete_claim = database.delete_claim
-split_into_sections = sectioning.split_into_sections
-build_section_text_map = citation_linking.build_section_text_map
 get_citation_display_data = citation_linking.get_citation_display_data
 get_angle_citation_display_data = citation_linking.get_angle_citation_display_data
 
@@ -881,12 +878,9 @@ def _run_full_analysis(
             policy_file.name,
         )
 
-        # Step 1b: Extract raw sections for citation linking (in-memory only)
-        uploaded_pdf_path = Path(policy_result.get("artifacts", {}).get("uploaded_pdf", ""))
-        if uploaded_pdf_path.is_file():
-            policy_text = load_pdf_text(uploaded_pdf_path)
-            raw_sections = split_into_sections(policy_text)
-            section_map = build_section_text_map(raw_sections)
+        # Step 1b: Reuse in-memory section text map from policy analysis.
+        section_map = policy_result.get("section_text_map") or {}
+        if section_map:
             st.session_state[SESSION_KEY_SECTION_MAP] = section_map
 
         # Step 2: denial text

--- a/src/demo_api.py
+++ b/src/demo_api.py
@@ -5,7 +5,8 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List
 
-from .run_baseline_policy_summary import summarize_policy
+from .citation_linking import build_section_text_map
+from .run_baseline_policy_summary import summarize_policy_with_sections
 from .report_builder import (
     build_policy_report,
     render_markdown,
@@ -89,7 +90,8 @@ def run_policy_analysis(
 
     try:
         # This runs your existing end-to-end pipeline (PDF -> sections -> LLM summaries -> JSON).
-        summary_json_path = summarize_policy(pdf_path)
+        summary_json_path, raw_sections = summarize_policy_with_sections(pdf_path)
+        section_text_map = build_section_text_map(raw_sections)
 
         # Normalise into PolicyReport
         summary_data = json.loads(summary_json_path.read_text(encoding="utf-8"))
@@ -104,23 +106,24 @@ def run_policy_analysis(
         md_path.write_text(markdown_text, encoding="utf-8")
 
         return {
-        "policy_name": policy_report.policy_name,
-        "source_path": policy_report.source_path,
-        "stats": {
-            "num_sections": policy_report.num_sections,
-            "num_unknown_sections": policy_report.num_unknown_sections,
-            "num_meta_sections": policy_report.num_meta_sections,
-        },
-        "sections_substantive": sections_substantive,
-        "sections_meta": sections_meta,
-        "artifacts": {
-            "summary_json": str(summary_json_path),
-            "markdown_report": str(md_path),
-            "uploaded_pdf": str(pdf_path),
-            "safe_mode": settings.safe_mode,
-            "persist_raw_text": settings.persist_raw_text,
-        },
-        "markdown": markdown_text,
+            "policy_name": policy_report.policy_name,
+            "source_path": policy_report.source_path,
+            "stats": {
+                "num_sections": policy_report.num_sections,
+                "num_unknown_sections": policy_report.num_unknown_sections,
+                "num_meta_sections": policy_report.num_meta_sections,
+            },
+            "sections_substantive": sections_substantive,
+            "sections_meta": sections_meta,
+            "section_text_map": section_text_map,
+            "artifacts": {
+                "summary_json": str(summary_json_path),
+                "markdown_report": str(md_path),
+                "uploaded_pdf": str(pdf_path),
+                "safe_mode": settings.safe_mode,
+                "persist_raw_text": settings.persist_raw_text,
+            },
+            "markdown": markdown_text,
         }
     finally:
         # Always finish W&B run and log rollups

--- a/src/run_baseline_policy_summary.py
+++ b/src/run_baseline_policy_summary.py
@@ -130,13 +130,14 @@ def _resolve_output_dir() -> Path:
     return SAFE_DATA_PROCESSED_DIR if settings.safe_mode else DATA_PROCESSED_DIR
 
 
-def summarize_policy(pdf_path: Path) -> Path:
+def summarize_policy_with_sections(pdf_path: Path) -> tuple[Path, Dict[str, str]]:
     """
     End-to-end pipeline for a single policy PDF:
     - load text
     - split into sections (dict: section_name -> section_text)
     - summarize each section via LLM
     - write JSON to <output_dir>/<stem>.json
+    - return the JSON path and raw in-memory sections
     """
     print(f"\n[bold]Loading policy:[/bold] {pdf_path}")
     text = load_pdf_text(pdf_path)
@@ -188,6 +189,14 @@ def summarize_policy(pdf_path: Path) -> Path:
     )
     print(f"Saved summary to: [green]{out_path}[/green]")
 
+    return out_path, sections
+
+
+def summarize_policy(pdf_path: Path) -> Path:
+    """
+    End-to-end pipeline for a single policy PDF, returning only the JSON path.
+    """
+    out_path, _sections = summarize_policy_with_sections(pdf_path)
     return out_path
 
 

--- a/tests/test_remove_redundant_pdf_reprocessing.py
+++ b/tests/test_remove_redundant_pdf_reprocessing.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import frontend.app as frontend_app
+from src import demo_api
+from src import run_baseline_policy_summary as policy_summary
+from src.citation_linking import build_section_text_map
+
+
+class FakeSectionSummary:
+    def __init__(self, section_name: str) -> None:
+        self.section_name = section_name
+
+    def to_dict(self) -> dict:
+        return {
+            "section_name": self.section_name,
+            "summary_overall": f"Summary for {self.section_name}",
+            "key_coverages": [],
+            "key_exclusions": [],
+            "conditions_notable": [],
+            "dispute_angles_possible": [],
+        }
+
+
+def _patch_policy_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    sections: dict[str, str],
+) -> tuple[Mock, Mock]:
+    monkeypatch.setattr(policy_summary, "DATA_PROCESSED_DIR", tmp_path / "processed")
+    monkeypatch.setattr(policy_summary, "SAFE_DATA_PROCESSED_DIR", tmp_path / "safe")
+    monkeypatch.setattr(
+        policy_summary,
+        "get_settings",
+        lambda: SimpleNamespace(persist_raw_text=False, safe_mode=False),
+    )
+
+    load_pdf_text = Mock(return_value="policy text")
+    split_into_sections = Mock(return_value=sections)
+    monkeypatch.setattr(policy_summary, "load_pdf_text", load_pdf_text)
+    monkeypatch.setattr(policy_summary, "split_into_sections", split_into_sections)
+    monkeypatch.setattr(
+        policy_summary,
+        "summarize_section",
+        Mock(
+            side_effect=lambda section_name, section_text: FakeSectionSummary(
+                section_name
+            )
+        ),
+    )
+    return load_pdf_text, split_into_sections
+
+
+def test_summarize_policy_with_sections_returns_output_path_and_raw_sections(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    raw_sections = {"COVERAGE A": "Dwelling text", "CONDITIONS": "Duties text"}
+    _patch_policy_summary(monkeypatch, tmp_path, raw_sections)
+
+    out_path, returned_sections = policy_summary.summarize_policy_with_sections(
+        tmp_path / "policy.pdf"
+    )
+
+    assert out_path == tmp_path / "processed" / "policy.json"
+    assert returned_sections is raw_sections
+    assert out_path.is_file()
+
+
+def test_summarize_policy_remains_path_only_backward_compatible(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_policy_summary(monkeypatch, tmp_path, {"COVERAGE A": "Dwelling text"})
+
+    out_path = policy_summary.summarize_policy(tmp_path / "policy.pdf")
+
+    assert isinstance(out_path, Path)
+    assert out_path == tmp_path / "processed" / "policy.json"
+
+
+def test_summarize_policy_with_sections_loads_and_splits_pdf_once(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    load_pdf_text, split_into_sections = _patch_policy_summary(
+        monkeypatch,
+        tmp_path,
+        {"COVERAGE A": "Dwelling text"},
+    )
+
+    policy_summary.summarize_policy_with_sections(tmp_path / "policy.pdf")
+
+    load_pdf_text.assert_called_once_with(tmp_path / "policy.pdf")
+    split_into_sections.assert_called_once_with("policy text")
+
+
+def test_run_policy_analysis_returns_in_memory_section_text_map(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    raw_sections = {
+        "COVERAGE A": "Dwelling text",
+        "CONDITIONS": "Duties text",
+        "UNKNOWN": "Excluded unknown text",
+    }
+    summary_json_path = tmp_path / "processed" / "uploaded.json"
+    summary_json_path.parent.mkdir()
+    summary_json_path.write_text(
+        json.dumps(
+            {
+                "policy_id": "uploaded",
+                "policy_path": "uploaded.pdf",
+                "sections": [
+                    {
+                        "section_name": "COVERAGE A",
+                        "summary_overall": "Dwelling summary",
+                        "key_coverages": [],
+                        "key_exclusions": [],
+                        "conditions_notable": [],
+                        "dispute_angles_possible": [],
+                        "raw_text": "Dwelling text",
+                        "section_role": "substantive",
+                    },
+                    {
+                        "section_name": "CONDITIONS",
+                        "summary_overall": "Duties summary",
+                        "key_coverages": [],
+                        "key_exclusions": [],
+                        "conditions_notable": [],
+                        "dispute_angles_possible": [],
+                        "raw_text": "Duties text",
+                        "section_role": "substantive",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(demo_api, "UPLOAD_DIR", tmp_path / "uploads")
+    monkeypatch.setattr(
+        demo_api,
+        "get_settings",
+        lambda: SimpleNamespace(safe_mode=False, persist_raw_text=False),
+    )
+    monkeypatch.setattr(demo_api, "start_wandb_run", lambda **kwargs: None)
+    monkeypatch.setattr(demo_api, "finish_wandb_run", lambda: None)
+    monkeypatch.setattr(
+        demo_api,
+        "summarize_policy_with_sections",
+        Mock(return_value=(summary_json_path, raw_sections)),
+    )
+
+    policy_result = demo_api.run_policy_analysis(b"%PDF", "uploaded.pdf")
+
+    expected_map = build_section_text_map(raw_sections)
+    assert policy_result["section_text_map"] == expected_map
+    assert list(policy_result["section_text_map"]) == ["COVERAGE A", "CONDITIONS"]
+    assert "section_text_map" not in policy_result["artifacts"]
+    assert "raw_text" not in policy_result["sections_substantive"][0]
+
+
+class _FakeStatus:
+    def __init__(self) -> None:
+        self.updates: list[dict] = []
+
+    def __enter__(self) -> "_FakeStatus":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def update(self, **kwargs) -> None:
+        self.updates.append(kwargs)
+
+
+class _FakeProgress:
+    def __init__(self) -> None:
+        self.values: list[int] = []
+
+    def progress(self, value: int) -> None:
+        self.values.append(value)
+
+
+class _FakeStreamlit:
+    def __init__(self) -> None:
+        self.session_state: dict[str, object] = {}
+
+    def status(self, *args, **kwargs) -> _FakeStatus:
+        return _FakeStatus()
+
+    def progress(self, value: int) -> _FakeProgress:
+        progress = _FakeProgress()
+        progress.progress(value)
+        return progress
+
+    def write(self, *args, **kwargs) -> None:
+        return None
+
+
+def test_frontend_live_path_uses_policy_result_section_map_without_reprocessing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    summary_json_path = tmp_path / "policy.json"
+    summary_json_path.write_text(
+        json.dumps({"policy_id": "policy", "sections": []}),
+        encoding="utf-8",
+    )
+    policy_pdf_path = tmp_path / "uploaded_policy.pdf"
+    policy_pdf_path.write_bytes(b"%PDF policy")
+    denial_path = tmp_path / "denial.pdf"
+    denial_path.write_bytes(b"%PDF denial")
+    section_map = {"COVERAGE A": "Dwelling text"}
+    fake_st = _FakeStreamlit()
+    load_pdf_text = Mock(return_value="denial text")
+
+    monkeypatch.setattr(frontend_app, "st", fake_st)
+    monkeypatch.setattr(frontend_app, "is_demo_force_on", lambda: False)
+    monkeypatch.setattr(
+        frontend_app,
+        "run_policy_analysis",
+        Mock(
+            return_value={
+                "policy_name": "policy",
+                "source_path": str(policy_pdf_path),
+                "section_text_map": section_map,
+                "artifacts": {
+                    "summary_json": str(summary_json_path),
+                    "uploaded_pdf": str(policy_pdf_path),
+                },
+            }
+        ),
+    )
+    monkeypatch.setattr(frontend_app, "_save_denial_pdf", lambda uploaded, nickname: denial_path)
+    monkeypatch.setattr(frontend_app, "load_pdf_text", load_pdf_text)
+    monkeypatch.setattr(
+        frontend_app,
+        "build_denial_aware_report",
+        lambda policy_summary_payload, denial_text: SimpleNamespace(
+            policy_id=None,
+            denial_id=None,
+            to_dict=lambda: {"plain_summary": "done"},
+        ),
+    )
+    monkeypatch.setattr(frontend_app, "render_dispute_markdown", lambda *args, **kwargs: "md")
+
+    policy_file = SimpleNamespace(
+        name="uploaded_policy.pdf",
+        getvalue=lambda: b"%PDF policy",
+    )
+    denial_file = SimpleNamespace(name="denial.pdf")
+
+    frontend_app._run_full_analysis(
+        claim_nickname="Kitchen",
+        state="TX",
+        policy_file=policy_file,
+        denial_file=denial_file,
+    )
+
+    assert fake_st.session_state[frontend_app.SESSION_KEY_SECTION_MAP] == section_map
+    load_pdf_text.assert_called_once_with(denial_path)
+
+
+def test_frontend_live_path_empty_section_map_does_not_overwrite_session_map(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    summary_json_path = tmp_path / "policy.json"
+    summary_json_path.write_text(
+        json.dumps({"policy_id": "policy", "sections": []}),
+        encoding="utf-8",
+    )
+    existing_map = {"EXISTING": "Keep me"}
+    fake_st = _FakeStreamlit()
+    fake_st.session_state[frontend_app.SESSION_KEY_SECTION_MAP] = existing_map
+
+    monkeypatch.setattr(frontend_app, "st", fake_st)
+    monkeypatch.setattr(frontend_app, "is_demo_force_on", lambda: False)
+    monkeypatch.setattr(
+        frontend_app,
+        "run_policy_analysis",
+        Mock(
+            return_value={
+                "policy_name": "policy",
+                "source_path": "",
+                "artifacts": {"summary_json": str(summary_json_path)},
+            }
+        ),
+    )
+    monkeypatch.setattr(frontend_app, "_save_denial_pdf", lambda uploaded, nickname: tmp_path / "denial.pdf")
+    monkeypatch.setattr(frontend_app, "load_pdf_text", Mock(return_value="denial text"))
+    monkeypatch.setattr(
+        frontend_app,
+        "build_denial_aware_report",
+        lambda policy_summary_payload, denial_text: SimpleNamespace(
+            policy_id=None,
+            denial_id=None,
+            to_dict=lambda: {"plain_summary": "done"},
+        ),
+    )
+    monkeypatch.setattr(frontend_app, "render_dispute_markdown", lambda *args, **kwargs: "md")
+
+    frontend_app._run_full_analysis(
+        claim_nickname="Kitchen",
+        state="TX",
+        policy_file=SimpleNamespace(name="policy.pdf", getvalue=lambda: b"%PDF"),
+        denial_file=SimpleNamespace(name="denial.pdf"),
+    )
+
+    assert fake_st.session_state[frontend_app.SESSION_KEY_SECTION_MAP] is existing_map

--- a/tests/test_remove_redundant_pdf_reprocessing.py
+++ b/tests/test_remove_redundant_pdf_reprocessing.py
@@ -200,6 +200,65 @@ class _FakeStreamlit:
         return None
 
 
+class _FakeIntakeStreamlit:
+    def __init__(self, policy_file, denial_file) -> None:
+        self.session_state: dict[str, object] = {}
+        self.policy_file = policy_file
+        self.denial_file = denial_file
+        self.successes: list[str] = []
+        self.warnings: list[str] = []
+
+    def __enter__(self) -> "_FakeIntakeStreamlit":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def header(self, *args, **kwargs) -> None:
+        return None
+
+    def info(self, *args, **kwargs) -> None:
+        return None
+
+    def caption(self, *args, **kwargs) -> None:
+        return None
+
+    def form(self, *args, **kwargs) -> "_FakeIntakeStreamlit":
+        return self
+
+    def columns(self, count: int):
+        return [self for _ in range(count)]
+
+    def text_input(self, label: str, **kwargs) -> str:
+        if label.startswith("Claim nickname"):
+            return "Kitchen"
+        if label.startswith("State"):
+            return "TX"
+        return ""
+
+    def file_uploader(self, label: str, **kwargs):
+        if label == "Policy PDF":
+            return self.policy_file
+        if label == "Denial letter PDF":
+            return self.denial_file
+        return None
+
+    def form_submit_button(self, *args, **kwargs) -> bool:
+        return True
+
+    def error(self, *args, **kwargs) -> None:
+        return None
+
+    def stop(self) -> None:
+        raise RuntimeError("streamlit stop")
+
+    def success(self, message: str) -> None:
+        self.successes.append(message)
+
+    def warning(self, message: str) -> None:
+        self.warnings.append(message)
+
+
 def test_frontend_live_path_uses_policy_result_section_map_without_reprocessing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -309,3 +368,43 @@ def test_frontend_live_path_empty_section_map_does_not_overwrite_session_map(
     )
 
     assert fake_st.session_state[frontend_app.SESSION_KEY_SECTION_MAP] is existing_map
+
+
+def test_intake_persistence_strips_section_text_map_without_changing_memory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy_file = SimpleNamespace(name="policy.pdf")
+    denial_file = SimpleNamespace(name="denial.pdf")
+    fake_st = _FakeIntakeStreamlit(policy_file, denial_file)
+    raw_policy_text = "RAW POLICY TEXT THAT MUST NOT BE PERSISTED"
+    policy_result = {
+        "policy_name": "policy",
+        "sections_substantive": [],
+        "section_text_map": {"COVERAGE A": raw_policy_text},
+        "artifacts": {"summary_json": "policy.json"},
+    }
+    dispute_result = {"dispute_report": {"plain_summary": "done"}}
+    saved_payloads: list[dict] = []
+
+    monkeypatch.setattr(frontend_app, "st", fake_st)
+    monkeypatch.setattr(frontend_app, "is_demo_force_on", lambda: False)
+    monkeypatch.setattr(
+        frontend_app,
+        "_run_full_analysis",
+        lambda **kwargs: (policy_result, dispute_result),
+    )
+
+    def fake_save_claim(**kwargs) -> int:
+        saved_payloads.append(kwargs)
+        return 123
+
+    monkeypatch.setattr(frontend_app, "save_claim", fake_save_claim)
+
+    frontend_app._render_intake_form()
+
+    assert fake_st.session_state[frontend_app.SESSION_KEY_POLICY] is policy_result
+    assert policy_result["section_text_map"] == {"COVERAGE A": raw_policy_text}
+
+    persisted_policy = saved_payloads[0]["report_json"]["policy_result"]
+    assert "section_text_map" not in persisted_policy
+    assert raw_policy_text not in json.dumps(saved_payloads[0]["report_json"])


### PR DESCRIPTION
Closes #51.

## Scope summary
- Added `summarize_policy_with_sections(...)` so live policy analysis can reuse the raw sections from the first PDF load/split.
- Updated `run_policy_analysis(...)` to build an in-memory `section_text_map` from those raw sections and return it at the top level.
- Updated the Streamlit live path to consume `policy_result["section_text_map"]` instead of loading/splitting the uploaded policy PDF again.
- Added focused regression coverage for the helper, API result shape, raw text stripping, section-map ordering, and Streamlit live-path behavior.

## Files changed
- `src/run_baseline_policy_summary.py`
- `src/demo_api.py`
- `frontend/app.py`
- `tests/test_remove_redundant_pdf_reprocessing.py`

## Implementation notes
Raw sections from the initial policy-analysis pass now build the citation/source section map in memory. The map is returned as `policy_result["section_text_map"]` and then stored in `st.session_state[SESSION_KEY_SECTION_MAP]` for the existing citation/source accordions. The map is not written to disk and is not added under `artifacts`.

## Tests
- `python -m pytest -q` passes: 73 passed.

## Boundaries preserved
- No prompt changes.
- No schema/dataclass changes.
- No Structured Outputs changes.
- No model changes.
- No retry changes.
- No telemetry changes.
- No section-summary concurrency changes.
- No benchmark changes.
- No Demo Mode behavior changes.
- No citation accordion behavior changes.
- No raw text persistence expansion.

## Deferred work
- Focused-analysis mode remains deferred to #52.
- Final benchmark comparison reporting remains deferred to #53.

## Manual validation
Automated tests were run. Demo Mode and live UI manual flows were not run in this session.