### PR TITLE
[codex] docs: sync post-64 phase status

### DIFF
--- a/docs/01-current-state.md
+++ b/docs/01-current-state.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated: 2026-04-25
+Last updated: 2026-04-26
 
 Phase 1 is complete. The app remains a Streamlit research prototype with deterministic Demo Mode, a live API-backed local workflow, README screenshots, and explicit AI-generated / not-legal-advice framing.
 
@@ -27,6 +27,7 @@ Phase 1 is complete. The app remains a Streamlit research prototype with determi
 - PR #58: #48 Structured Outputs for final dispute report generation only.
 - PR #60: #49 stage-specific model configuration via `OPENAI_MODEL_<STAGE_UPPER>`.
 - PR #62: #50 bounded concurrency for section-summary LLM calls.
+- PR #64: #51 redundant live policy PDF reprocessing cleanup.
 
 ## Current Phase
 
@@ -40,13 +41,15 @@ Phase 1C local/demo trust polish is complete with #21 Demo Mode citation/source 
 
 #20 walkthrough video and screenshot recipe is intentionally deferred because walkthrough/video work should wait until after Phase 2 stabilizes.
 
-Phase 2 baseline benchmarking is complete via #46 / PR #54. #47 Responses API migration is complete via PR #56. #48 Structured Outputs is complete via PR #58 for final dispute report generation only. #49 stage-specific model configuration is complete via PR #60. #50 section-summary latency reduction is complete via PR #62.
+Phase 2 baseline benchmarking is complete via #46 / PR #54. #47 Responses API migration is complete via PR #56. #48 Structured Outputs is complete via PR #58 for final dispute report generation only. #49 stage-specific model configuration is complete via PR #60. #50 section-summary latency reduction is complete via PR #62. #51 redundant live policy PDF reprocessing cleanup is complete via PR #64.
 
 Stage-specific model overrides are available through `OPENAI_MODEL_<STAGE_UPPER>`, such as `OPENAI_MODEL_SECTION_SUMMARY` and `OPENAI_MODEL_DISPUTE_REPORT`. Default model behavior is unchanged unless a per-stage override is explicitly set.
 
 Section summaries intentionally remain on the default `json_object` mode. Section-summary calls now use bounded concurrency via `ThreadPoolExecutor`; `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior.
 
-The next intended issue is #51 redundant PDF reprocessing cleanup in the live pipeline. PDF reprocessing cleanup remains deferred to #51; no PDF processing changes, model swaps, prompt changes, dataclass/schema refactors, parser changes, benchmark changes, or speed refactors beyond #50 have started.
+PR #64 removed live policy PDF reprocessing by reusing the first-pass raw sections for the in-memory citation source map. `section_text_map` is stripped before claim persistence to avoid persisting raw policy text with saved claims.
+
+The next intended issue is #52 focused-analysis mode. Do not start #52 as part of post-#64 hygiene; no focused-analysis mode, prompt changes, dataclass/schema refactors, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, benchmark changes, deployment/auth/storage work, or PDF export work have started.
 
 ## Local Cleanup
 

--- a/docs/03-roadmap.md
+++ b/docs/03-roadmap.md
@@ -32,13 +32,13 @@ Intentionally deferred:
 - #18 Streamlit Community Cloud deployment prep - revisit only when a hosted public demo is needed.
 - #20 walkthrough video/screenshot recipe - revisit after Phase 2 stabilizes.
 
-## Phase 2: Model and speed refactor - section summary concurrency complete
+## Phase 2: Model and speed refactor - PDF reprocessing cleanup complete
 
-True Phase 2 remains reserved for model/speed/API refactor work. Baseline measurement is complete via #46 / PR #54. The Responses API migration is complete via #47 / PR #56. Structured Outputs for final dispute report generation is complete via #48 / PR #58. Stage-specific model configuration is complete via #49 / PR #60. Section-summary latency reduction is complete via #50 / PR #62. The next intended issue is #51 redundant PDF reprocessing cleanup in the live pipeline.
+True Phase 2 remains reserved for model/speed/API refactor work. Baseline measurement is complete via #46 / PR #54. The Responses API migration is complete via #47 / PR #56. Structured Outputs for final dispute report generation is complete via #48 / PR #58. Stage-specific model configuration is complete via #49 / PR #60. Section-summary latency reduction is complete via #50 / PR #62. Redundant live policy PDF reprocessing cleanup is complete via #51 / PR #64. The next intended issue is #52 focused-analysis mode.
 
 Gating rule:
 
-#50 added bounded concurrency for section-summary LLM calls only. Section-summary calls now use `ThreadPoolExecutor`; `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior. PDF reprocessing cleanup remains deferred to #51. Do not bundle prompt rewrites, report schema changes, benchmark changes, model swaps, or unrelated refactors into the PDF reprocessing cleanup PR.
+#50 added bounded concurrency for section-summary LLM calls only. Section-summary calls now use `ThreadPoolExecutor`; `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior. #51 removed the second live policy PDF pass by reusing first-pass raw sections for the in-memory citation source map, and `section_text_map` is stripped before claim persistence to avoid raw policy text persistence. Do not bundle prompt rewrites, report schema changes, benchmark changes, model swaps, or unrelated refactors into #52.
 
 Order:
 
@@ -48,8 +48,8 @@ Order:
    Section summaries intentionally remain on `json_object` mode.
 4. Add stage-specific model configuration: complete via #49 / PR #60.
 5. Parallelize per-section LLM calls: complete via #50 / PR #62.
-6. Remove redundant PDF reprocessing in the live pipeline: next via #51.
-7. Add focused-analysis mode.
+6. Remove redundant PDF reprocessing in the live pipeline: complete via #51 / PR #64.
+7. Add focused-analysis mode: next via #52.
 8. Final benchmark report comparing latency, cost, and report quality against the Phase 2 baseline.
 
 ## Out of scope across all phases

--- a/docs/06-heartbeat.md
+++ b/docs/06-heartbeat.md
@@ -1,6 +1,6 @@
 # Heartbeat
 
-Last updated: 2026-04-25 23:59 ET
+Last updated: 2026-04-26 00:27 ET
 
 ## Current Phase
 - Phase 1 is complete: Phase 1A demo polish, Phase 1B technical closeout, and Phase 1C local/demo trust polish.
@@ -9,6 +9,7 @@ Last updated: 2026-04-25 23:59 ET
 - Phase 2 Structured Outputs for final dispute report generation is complete via #48 / PR #58.
 - Phase 2 stage-specific model configuration is complete via #49 / PR #60.
 - Phase 2 section-summary latency reduction is complete via #50 / PR #62.
+- Phase 2 redundant live policy PDF reprocessing cleanup is complete via #51 / PR #64.
 
 ## Current Truth
 - PR #44 wrapped Phase 1 and handed off to Phase 2 baseline benchmarking.
@@ -17,6 +18,8 @@ Last updated: 2026-04-25 23:59 ET
 - PR #58 added Responses API Structured Outputs strict JSON Schema mode only for final dispute report generation. Section summaries intentionally remain on default `json_object` mode.
 - PR #60 added optional stage-specific model overrides through `OPENAI_MODEL_<STAGE_UPPER>`, while preserving default model behavior unless per-stage overrides are explicitly set.
 - PR #62 added bounded concurrency for section-summary LLM calls using `ThreadPoolExecutor`. `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior.
+- PR #64 removed live policy PDF reprocessing by reusing first-pass raw sections for the in-memory citation source map.
+- PR #64 strips `section_text_map` before claim persistence to avoid persisting raw policy text.
 - The checked-in baseline is deterministic demo-bundle mode with no API calls.
 - #21 Demo Mode citation/source accordions are complete via PR #41.
 - Demo source-map loading hardening is complete via PR #42.
@@ -24,7 +27,7 @@ Last updated: 2026-04-25 23:59 ET
 - The repo remains a research prototype with AI-generated and not-legal-advice framing.
 
 ## Next Action
-- Start #51 redundant PDF reprocessing cleanup in the live pipeline only. PDF reprocessing cleanup remains deferred to #51; do not bundle prompt rewrites, report schema changes, benchmark changes, model swaps, telemetry changes, frontend behavior changes, or unrelated refactors.
+- Start #52 focused-analysis mode only. Do not bundle prompt rewrites, report schema changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, benchmark changes, deployment/auth/storage work, PDF export work, or unrelated refactors.
 
 ## Deferred
 - #18 Streamlit deployment prep — deferred because hosted deployment is not needed yet and adds surface area.
@@ -32,10 +35,12 @@ Last updated: 2026-04-25 23:59 ET
 
 ## Watchouts
 - #46 baseline benchmarking is complete; use it as the before-state reference for remaining Phase 2 work.
-- #47 Responses API migration is complete; do not re-open API migration work while starting #51.
-- #48 Structured Outputs is complete for final dispute report generation only; do not expand it while starting #51.
-- #49 stage-specific model configuration is complete; do not tune model choices by default while starting #51.
-- #50 section-summary concurrency is complete; do not rework prompts, schemas, model configuration, retry behavior, telemetry, or benchmark code while starting #51.
+- #47 Responses API migration is complete; do not re-open API migration work while starting #52.
+- #48 Structured Outputs is complete for final dispute report generation only; do not expand it while starting #52.
+- #49 stage-specific model configuration is complete; do not tune model choices by default while starting #52.
+- #50 section-summary concurrency is complete; do not rework prompts, schemas, model configuration, retry behavior, telemetry, or benchmark code while starting #52.
+- #51 redundant live policy PDF reprocessing cleanup is complete; do not re-open PDF processing while starting #52.
 - Section summaries remain on `json_object` mode unless a later issue explicitly changes that.
 - Section-summary calls use bounded `ThreadPoolExecutor` concurrency; keep `SECTION_SUMMARY_MAX_WORKERS=1` as the sequential kill-switch.
+- The live citation source map reuses first-pass raw sections in memory; `section_text_map` is stripped before claim persistence.
 - Preserve research prototype / AI-generated / not legal advice framing.

--- a/docs/08-memory.md
+++ b/docs/08-memory.md
@@ -13,10 +13,13 @@ Durable project timeline for future Codex and Claude sessions.
 - Phase 2 Structured Outputs for final dispute report generation is complete via #48 / PR #58.
 - Phase 2 stage-specific model configuration is complete via #49 / PR #60.
 - Phase 2 section-summary latency reduction is complete via #50 / PR #62.
+- Phase 2 redundant live policy PDF reprocessing cleanup is complete via #51 / PR #64.
 - Stage-specific model overrides use `OPENAI_MODEL_<STAGE_UPPER>` and default model behavior is unchanged unless a per-stage override is explicitly set.
 - Section summaries intentionally remain on default `json_object` mode.
 - Section-summary calls now use bounded concurrency via `ThreadPoolExecutor`. `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior.
-- Next: start #51 redundant PDF reprocessing cleanup in the live pipeline only. PDF reprocessing cleanup remains deferred to #51. Do not bundle prompt rewrites, report schema changes, benchmark changes, model swaps, telemetry changes, frontend behavior changes, or unrelated refactors in the #51 PR.
+- #51 removed live policy PDF reprocessing by reusing first-pass raw sections for the in-memory citation source map.
+- `section_text_map` is stripped before claim persistence to avoid raw policy text persistence.
+- Next: start #52 focused-analysis mode only. Do not bundle prompt rewrites, report schema changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, benchmark changes, deployment/auth/storage work, PDF export work, or unrelated refactors in the #52 PR.
 
 ## Timeline
 
@@ -34,6 +37,7 @@ Durable project timeline for future Codex and Claude sessions.
 | 2026-04-25 23:19 ET | Structured Outputs for dispute reports merged | #48 / PR #58 | Added strict JSON Schema mode only to final dispute report generation; section summaries remain on `json_object` mode. |
 | 2026-04-25 23:37 ET | Stage-specific model configuration merged | #49 / PR #60 | Added optional `OPENAI_MODEL_<STAGE_UPPER>` overrides while preserving default model behavior unless explicitly configured. |
 | 2026-04-25 23:58 ET | Section-summary concurrency merged | #50 / PR #62 | Added bounded `ThreadPoolExecutor` concurrency for section-summary LLM calls; `SECTION_SUMMARY_MAX_WORKERS=1` remains the sequential kill-switch. |
+| 2026-04-26 00:25 ET | Redundant live policy PDF reprocessing cleanup merged | #51 / PR #64 | Reuses first-pass raw sections for the in-memory citation source map and strips `section_text_map` before claim persistence to avoid raw policy text persistence. |
 
 ## Standing Guardrails
 

--- a/docs/09-session-log.md
+++ b/docs/09-session-log.md
@@ -229,3 +229,30 @@ Track real working sessions so future AI/dev sessions can quickly understand wha
 
 #### Next session starter
 - Start #51 only: remove redundant PDF reprocessing from the live pipeline, without prompt rewrites, report schema changes, Structured Outputs changes, model configuration changes, retry changes, telemetry changes, benchmark changes, frontend behavior changes, or unrelated refactors.
+
+### 2026-04-26 00:27 ET - Post-#64 hygiene truth sync
+
+#### Goal
+- Confirm #51 / PR #64 post-merge state and align durable docs with #52 as the next intended issue.
+
+#### Completed
+- Confirmed PR #64 is merged and issue #51 is closed.
+- Confirmed #52 is open and next in the Phase 2 order.
+- Updated durable docs to mark #51 complete and #52 next.
+- Recorded that live policy PDF reprocessing was removed by reusing first-pass raw sections for the in-memory citation source map.
+- Recorded that `section_text_map` is stripped before claim persistence to avoid raw policy text persistence.
+
+#### Decisions
+- No new technical decisions.
+
+#### Validation
+- Git/GitHub hygiene checks completed.
+- Docs-only diff reviewed.
+- `git diff --check` passed.
+
+#### Deferred
+- #52 focused-analysis mode remains deferred to the next issue.
+- Prompt rewrites, schema/dataclass changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, benchmark changes, deployment/auth/storage work, and PDF export work remain out of scope.
+
+#### Next session starter
+- Start #52 only: focused-analysis mode, without prompt rewrites, schema/dataclass changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, benchmark changes, deployment/auth/storage work, PDF export work, or unrelated refactors.


### PR DESCRIPTION
## Summary
- Mark #51 / PR #64 complete across current-state, roadmap, heartbeat, memory, and session log docs.
- Record that PR #64 removed live policy PDF reprocessing by reusing first-pass raw sections for the in-memory citation source map.
- Record that `section_text_map` is stripped before claim persistence to avoid raw policy text persistence.
- Set #52 focused-analysis mode as the next intended issue without starting it.

## Validation
- `git diff --check`
- Confirmed changed files are docs-only.