### PR TITLE
Add focused analysis mode

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -491,6 +491,7 @@ def _build_export_context(
     policy_filename: str | None = None,
     denial_filename: str | None = None,
     demo_mode: bool = False,
+    analysis_mode: str | None = None,
 ) -> Dict[str, Any]:
     claim_metadata = claim_metadata or {}
     context: Dict[str, Any] = {"generated_date": date.today().isoformat()}
@@ -511,10 +512,24 @@ def _build_export_context(
         context["policy_filename"] = policy_filename
     if denial_filename:
         context["denial_filename"] = denial_filename
+    mode_label = _analysis_mode_label(
+        analysis_mode or str(claim_metadata.get("analysis_mode", "") or "")
+    )
+    if mode_label:
+        context["analysis_mode"] = mode_label
     if demo_mode:
         context["demo_mode"] = True
 
     return context
+
+
+def _analysis_mode_label(analysis_mode: str | None) -> str:
+    mode = str(analysis_mode or "").strip().lower()
+    if mode == "focused":
+        return "Focused"
+    if mode == "full":
+        return "Full"
+    return ""
 
 
 def _render_hero(
@@ -525,6 +540,7 @@ def _render_hero(
     denial_filename: str | None = None,
     claim_metadata: Dict[str, Any] | None = None,
     demo_mode: bool = False,
+    analysis_mode: str | None = None,
 ) -> None:
     st.subheader("Dispute overview")
 
@@ -576,6 +592,12 @@ def _render_hero(
         st.markdown("##### Review context")
         st.write(f"**Policy file:** {policy_filename or policy_label}")
         st.write(f"**Denial file:** {denial_filename or denial_label}")
+        mode_label = _analysis_mode_label(
+            analysis_mode
+            or str((claim_metadata or {}).get("analysis_mode", "") or "")
+        )
+        if mode_label:
+            st.write(f"**Analysis mode:** {mode_label}")
         if score is not None:
             try:
                 st.metric("Confidence", f"{float(score):.2f}")
@@ -588,6 +610,7 @@ def _render_hero(
             policy_filename=policy_filename,
             denial_filename=denial_filename,
             demo_mode=demo_mode,
+            analysis_mode=analysis_mode,
         )
         export_docx = render_dispute_docx(report_obj, context=export_context)
         export_markdown = render_dispute_markdown(report_obj, context=export_context)
@@ -850,6 +873,7 @@ def _run_full_analysis(
     state: str,
     policy_file,
     denial_file,
+    focused: bool = False,
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """
     End-to-end:
@@ -876,7 +900,9 @@ def _run_full_analysis(
         policy_result = run_policy_analysis(
             policy_file.getvalue(),
             policy_file.name,
+            focused=focused,
         )
+        analysis_mode = str(policy_result.get("analysis_mode") or "full")
 
         # Step 1b: Reuse in-memory section text map from policy analysis.
         section_map = policy_result.get("section_text_map") or {}
@@ -935,6 +961,7 @@ def _run_full_analysis(
                 },
                 policy_filename=policy_file.name,
                 denial_filename=denial_file.name,
+                analysis_mode=_analysis_mode_label(analysis_mode) or "Full",
             ),
         )
         dispute_report_dict = dispute_obj.to_dict()
@@ -942,11 +969,13 @@ def _run_full_analysis(
         dispute_result: Dict[str, Any] = {
             "policy_id": dispute_obj.policy_id,
             "denial_id": dispute_obj.denial_id,
+            "analysis_mode": analysis_mode,
             "dispute_report": dispute_report_dict,
             "markdown": markdown,
             "artifacts": {
                 "summary_json": str(summary_json_path),
                 "denial_pdf": str(denial_path),
+                "analysis_mode": analysis_mode,
             },
         }
 
@@ -1003,6 +1032,14 @@ def _render_intake_form() -> None:
             key="denial_pdf",
             help="The carrier's denial letter as a PDF.",
         )
+        focused_analysis = st.checkbox(
+            "Focused analysis - faster, core policy sections only",
+            value=False,
+            help=(
+                "Full analysis is the default. Focused analysis is narrower and "
+                "summarizes only core policy sections before building the dispute report."
+            ),
+        )
 
         submitted = st.form_submit_button("Analyze claim", type="primary")
 
@@ -1026,6 +1063,7 @@ def _render_intake_form() -> None:
             state=state.strip(),
             policy_file=policy_file,
             denial_file=denial_file,
+            focused=focused_analysis,
         )
     except Exception as e:
         st.error(f"Analysis failed: {e}")
@@ -1038,6 +1076,7 @@ def _render_intake_form() -> None:
         "state": state.strip(),
         "policy_filename": policy_file.name,
         "denial_filename": denial_file.name,
+        "analysis_mode": policy_result.get("analysis_mode") or "full",
     }
 
     policy_result_for_persistence = dict(policy_result)
@@ -1076,6 +1115,14 @@ def _render_results_section() -> None:
     policy_label = str(dispute_result.get("policy_id") or "policy")
     denial_label = str(dispute_result.get("denial_id") or "denial")
     claim_metadata = st.session_state.get(SESSION_KEY_CLAIM_METADATA, {}) or {}
+    analysis_mode = str(
+        policy_result.get("analysis_mode")
+        or dispute_result.get("analysis_mode")
+        or claim_metadata.get("analysis_mode")
+        or ""
+    )
+    if analysis_mode.lower() == "focused":
+        st.info("Focused analysis used: core policy sections only.")
 
     _render_hero(
         dispute_report,
@@ -1085,6 +1132,7 @@ def _render_results_section() -> None:
         denial_filename=claim_metadata.get("denial_filename"),
         claim_metadata=claim_metadata,
         demo_mode=bool(st.session_state.get(SESSION_KEY_DEMO_MODE)),
+        analysis_mode=analysis_mode,
     )
 
     st.markdown("### Detailed dispute views")
@@ -1171,6 +1219,11 @@ def _render_claim_history_page() -> None:
 
             policy_label = str(dispute_result.get("policy_id") or "policy")
             denial_label = str(dispute_result.get("denial_id") or "denial")
+            analysis_mode = str(
+                policy_result.get("analysis_mode")
+                or dispute_result.get("analysis_mode")
+                or ""
+            )
 
             st.divider()
 
@@ -1183,7 +1236,9 @@ def _render_claim_history_page() -> None:
                 claim_metadata={
                     "nickname": claim.nickname,
                     "state": claim.state,
+                    "analysis_mode": analysis_mode,
                 },
+                analysis_mode=analysis_mode,
             )
 
             st.markdown("### Detailed dispute views")

--- a/src/demo_api.py
+++ b/src/demo_api.py
@@ -66,6 +66,8 @@ def _resolve_dispute_output_dir() -> Path:
 def run_policy_analysis(
     policy_file_bytes: bytes,
     policy_filename: str,
+    *,
+    focused: bool = False,
 ) -> Dict[str, Any]:
     """
     High-level service for the v0 frontend.
@@ -90,11 +92,15 @@ def run_policy_analysis(
 
     try:
         # This runs your existing end-to-end pipeline (PDF -> sections -> LLM summaries -> JSON).
-        summary_json_path, raw_sections = summarize_policy_with_sections(pdf_path)
+        summary_json_path, raw_sections = summarize_policy_with_sections(
+            pdf_path,
+            focused=focused,
+        )
         section_text_map = build_section_text_map(raw_sections)
 
         # Normalise into PolicyReport
         summary_data = json.loads(summary_json_path.read_text(encoding="utf-8"))
+        analysis_mode = str(summary_data.get("analysis_mode") or "full")
         policy_report = build_policy_report(summary_data)
 
         sections_substantive = _strip_raw_text(policy_report.sections_substantive)
@@ -108,6 +114,7 @@ def run_policy_analysis(
         return {
             "policy_name": policy_report.policy_name,
             "source_path": policy_report.source_path,
+            "analysis_mode": analysis_mode,
             "stats": {
                 "num_sections": policy_report.num_sections,
                 "num_unknown_sections": policy_report.num_unknown_sections,
@@ -122,6 +129,7 @@ def run_policy_analysis(
                 "uploaded_pdf": str(pdf_path),
                 "safe_mode": settings.safe_mode,
                 "persist_raw_text": settings.persist_raw_text,
+                "analysis_mode": analysis_mode,
             },
             "markdown": markdown_text,
         }

--- a/src/report_builder.py
+++ b/src/report_builder.py
@@ -281,10 +281,13 @@ def _export_context_rows(
             rows.append((label, value))
 
     analysis_mode = _clean_context_value(context.get("analysis_mode"))
-    if analysis_mode:
+    if context.get("demo_mode"):
+        mode = "Demo Mode"
+        if analysis_mode:
+            mode = f"{mode} ({analysis_mode})"
+        rows.append(("Mode", mode))
+    elif analysis_mode:
         rows.append(("Mode", analysis_mode))
-    elif context.get("demo_mode"):
-        rows.append(("Mode", "Demo Mode"))
 
     return rows
 

--- a/src/report_builder.py
+++ b/src/report_builder.py
@@ -280,7 +280,10 @@ def _export_context_rows(
         if value:
             rows.append((label, value))
 
-    if context.get("demo_mode"):
+    analysis_mode = _clean_context_value(context.get("analysis_mode"))
+    if analysis_mode:
+        rows.append(("Mode", analysis_mode))
+    elif context.get("demo_mode"):
         rows.append(("Mode", "Demo Mode"))
 
     return rows

--- a/src/run_baseline_policy_summary.py
+++ b/src/run_baseline_policy_summary.py
@@ -101,6 +101,15 @@ except ImportError:
 DATA_PROCESSED_DIR = Path("data/processed")
 SAFE_DATA_PROCESSED_DIR = Path("data/processed_safe")
 DEFAULT_SECTION_SUMMARY_WORKERS = 4
+FOCUSED_SECTION_ALLOWLIST = {
+    "DEFINITIONS",
+    "EXCLUSIONS",
+    "CONDITIONS",
+    "COVERAGE A - DWELLING",
+    "COVERAGE B - OTHER STRUCTURES",
+    "COVERAGE C - PERSONAL PROPERTY",
+    "COVERAGE D - LOSS OF USE",
+}
 
 
 def _resolve_section_summary_workers() -> int:
@@ -130,7 +139,28 @@ def _resolve_output_dir() -> Path:
     return SAFE_DATA_PROCESSED_DIR if settings.safe_mode else DATA_PROCESSED_DIR
 
 
-def summarize_policy_with_sections(pdf_path: Path) -> tuple[Path, Dict[str, str]]:
+def _select_focused_sections(sections: Dict[str, str]) -> Dict[str, str]:
+    """
+    Select the v1 focused-analysis core section set, preserving detected order.
+    """
+    focused_sections: Dict[str, str] = {}
+
+    for section_name, raw_text in sections.items():
+        canonical_name = (section_name or "").strip().upper()
+        if canonical_name not in FOCUSED_SECTION_ALLOWLIST:
+            continue
+        if classify_section_role(section_name, raw_text) == "meta":
+            continue
+        focused_sections[section_name] = raw_text
+
+    return focused_sections
+
+
+def summarize_policy_with_sections(
+    pdf_path: Path,
+    *,
+    focused: bool = False,
+) -> tuple[Path, Dict[str, str]]:
     """
     End-to-end pipeline for a single policy PDF:
     - load text
@@ -144,6 +174,7 @@ def summarize_policy_with_sections(pdf_path: Path) -> tuple[Path, Dict[str, str]
 
     print("Splitting into sections...")
     sections: Dict[str, str] = split_into_sections(text)
+    sections_to_summarize = _select_focused_sections(sections) if focused else sections
 
     settings = get_settings()
     persist_raw_text = settings.persist_raw_text
@@ -172,7 +203,7 @@ def summarize_policy_with_sections(pdf_path: Path) -> tuple[Path, Dict[str, str]
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         results: List[dict] = list(
-            executor.map(summarize_section_item, sections.items())
+            executor.map(summarize_section_item, sections_to_summarize.items())
         )
 
     out_path = output_dir / f"{pdf_path.stem}.json"
@@ -180,6 +211,7 @@ def summarize_policy_with_sections(pdf_path: Path) -> tuple[Path, Dict[str, str]
     payload = {
         "policy_id": pdf_path.stem,
         "policy_path": str(pdf_path),
+        "analysis_mode": "focused" if focused else "full",
         "sections": results,
     }
 
@@ -192,11 +224,15 @@ def summarize_policy_with_sections(pdf_path: Path) -> tuple[Path, Dict[str, str]
     return out_path, sections
 
 
-def summarize_policy(pdf_path: Path) -> Path:
+def summarize_policy(
+    pdf_path: Path,
+    *,
+    focused: bool = False,
+) -> Path:
     """
     End-to-end pipeline for a single policy PDF, returning only the JSON path.
     """
-    out_path, _sections = summarize_policy_with_sections(pdf_path)
+    out_path, _sections = summarize_policy_with_sections(pdf_path, focused=focused)
     return out_path
 
 

--- a/tests/test_remove_redundant_pdf_reprocessing.py
+++ b/tests/test_remove_redundant_pdf_reprocessing.py
@@ -162,6 +162,77 @@ def test_run_policy_analysis_returns_in_memory_section_text_map(
     assert "raw_text" not in policy_result["sections_substantive"][0]
 
 
+def test_run_policy_analysis_forwards_focused_and_keeps_full_section_map(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    raw_sections = {
+        "DEFINITIONS": "Definitions text",
+        "COVERAGE A - DWELLING": "Dwelling text",
+        "LOSS SETTLEMENT": "Full raw section text still available for citations",
+    }
+    summary_json_path = tmp_path / "processed" / "uploaded.json"
+    summary_json_path.parent.mkdir()
+    summary_json_path.write_text(
+        json.dumps(
+            {
+                "policy_id": "uploaded",
+                "policy_path": "uploaded.pdf",
+                "analysis_mode": "focused",
+                "sections": [
+                    {
+                        "section_name": "DEFINITIONS",
+                        "summary_overall": "Definitions summary",
+                        "key_coverages": [],
+                        "key_exclusions": [],
+                        "conditions_notable": [],
+                        "dispute_angles_possible": [],
+                        "section_role": "substantive",
+                    },
+                    {
+                        "section_name": "COVERAGE A - DWELLING",
+                        "summary_overall": "Dwelling summary",
+                        "key_coverages": [],
+                        "key_exclusions": [],
+                        "conditions_notable": [],
+                        "dispute_angles_possible": [],
+                        "section_role": "substantive",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    summarize_mock = Mock(return_value=(summary_json_path, raw_sections))
+
+    monkeypatch.setattr(demo_api, "UPLOAD_DIR", tmp_path / "uploads")
+    monkeypatch.setattr(
+        demo_api,
+        "get_settings",
+        lambda: SimpleNamespace(safe_mode=False, persist_raw_text=False),
+    )
+    monkeypatch.setattr(demo_api, "start_wandb_run", lambda **kwargs: None)
+    monkeypatch.setattr(demo_api, "finish_wandb_run", lambda: None)
+    monkeypatch.setattr(
+        demo_api,
+        "summarize_policy_with_sections",
+        summarize_mock,
+    )
+
+    policy_result = demo_api.run_policy_analysis(
+        b"%PDF",
+        "uploaded.pdf",
+        focused=True,
+    )
+
+    assert summarize_mock.call_args.kwargs["focused"] is True
+    assert policy_result["analysis_mode"] == "focused"
+    assert policy_result["section_text_map"] == build_section_text_map(raw_sections)
+    assert "LOSS SETTLEMENT" in policy_result["section_text_map"]
+    assert "LOSS SETTLEMENT" not in [
+        section["section_name"] for section in policy_result["sections_substantive"]
+    ]
+
+
 class _FakeStatus:
     def __init__(self) -> None:
         self.updates: list[dict] = []
@@ -243,6 +314,9 @@ class _FakeIntakeStreamlit:
             return self.denial_file
         return None
 
+    def checkbox(self, *args, **kwargs) -> bool:
+        return False
+
     def form_submit_button(self, *args, **kwargs) -> bool:
         return True
 
@@ -320,6 +394,54 @@ def test_frontend_live_path_uses_policy_result_section_map_without_reprocessing(
 
     assert fake_st.session_state[frontend_app.SESSION_KEY_SECTION_MAP] == section_map
     load_pdf_text.assert_called_once_with(denial_path)
+
+
+def test_frontend_run_full_analysis_forwards_focused_true(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    summary_json_path = tmp_path / "policy.json"
+    summary_json_path.write_text(
+        json.dumps({"policy_id": "policy", "analysis_mode": "focused", "sections": []}),
+        encoding="utf-8",
+    )
+    denial_path = tmp_path / "denial.pdf"
+    denial_path.write_bytes(b"%PDF denial")
+    fake_st = _FakeStreamlit()
+    run_policy_analysis = Mock(
+        return_value={
+            "policy_name": "policy",
+            "source_path": "",
+            "analysis_mode": "focused",
+            "section_text_map": {},
+            "artifacts": {"summary_json": str(summary_json_path)},
+        }
+    )
+
+    monkeypatch.setattr(frontend_app, "st", fake_st)
+    monkeypatch.setattr(frontend_app, "is_demo_force_on", lambda: False)
+    monkeypatch.setattr(frontend_app, "run_policy_analysis", run_policy_analysis)
+    monkeypatch.setattr(frontend_app, "_save_denial_pdf", lambda uploaded, nickname: denial_path)
+    monkeypatch.setattr(frontend_app, "load_pdf_text", Mock(return_value="denial text"))
+    monkeypatch.setattr(
+        frontend_app,
+        "build_denial_aware_report",
+        lambda policy_summary_payload, denial_text: SimpleNamespace(
+            policy_id=None,
+            denial_id=None,
+            to_dict=lambda: {"plain_summary": "done"},
+        ),
+    )
+    monkeypatch.setattr(frontend_app, "render_dispute_markdown", lambda *args, **kwargs: "md")
+
+    frontend_app._run_full_analysis(
+        claim_nickname="Kitchen",
+        state="TX",
+        policy_file=SimpleNamespace(name="policy.pdf", getvalue=lambda: b"%PDF"),
+        denial_file=SimpleNamespace(name="denial.pdf"),
+        focused=True,
+    )
+
+    assert run_policy_analysis.call_args.kwargs["focused"] is True
 
 
 def test_frontend_live_path_empty_section_map_does_not_overwrite_session_map(

--- a/tests/test_report_export_context.py
+++ b/tests/test_report_export_context.py
@@ -53,6 +53,15 @@ def test_dispute_markdown_export_handles_no_context() -> None:
     assert "## A. Plain-English overview of the dispute" in markdown
 
 
+def test_dispute_markdown_export_includes_analysis_mode() -> None:
+    markdown = render_dispute_markdown(
+        _sample_report(),
+        context={"analysis_mode": "Focused"},
+    )
+
+    assert "- **Mode:** Focused" in markdown
+
+
 def test_dispute_docx_export_includes_human_context() -> None:
     docx_bytes = render_dispute_docx(
         _sample_report(),
@@ -74,3 +83,15 @@ def test_dispute_docx_export_includes_human_context() -> None:
     assert "Generated date: 2026-04-26" in text
     assert "Policy file: policy.pdf" in text
     assert "Denial file: denial.pdf" in text
+
+
+def test_dispute_docx_export_includes_analysis_mode() -> None:
+    docx_bytes = render_dispute_docx(
+        _sample_report(),
+        context={"analysis_mode": "Full"},
+    )
+
+    document = Document(io.BytesIO(docx_bytes))
+    text = "\n".join(paragraph.text for paragraph in document.paragraphs)
+
+    assert "Mode: Full" in text

--- a/tests/test_report_export_context.py
+++ b/tests/test_report_export_context.py
@@ -62,6 +62,15 @@ def test_dispute_markdown_export_includes_analysis_mode() -> None:
     assert "- **Mode:** Focused" in markdown
 
 
+def test_dispute_markdown_export_combines_demo_and_analysis_mode() -> None:
+    markdown = render_dispute_markdown(
+        _sample_report(),
+        context={"demo_mode": True, "analysis_mode": "Focused"},
+    )
+
+    assert "- **Mode:** Demo Mode (Focused)" in markdown
+
+
 def test_dispute_docx_export_includes_human_context() -> None:
     docx_bytes = render_dispute_docx(
         _sample_report(),
@@ -95,3 +104,15 @@ def test_dispute_docx_export_includes_analysis_mode() -> None:
     text = "\n".join(paragraph.text for paragraph in document.paragraphs)
 
     assert "Mode: Full" in text
+
+
+def test_dispute_docx_export_combines_demo_and_analysis_mode() -> None:
+    docx_bytes = render_dispute_docx(
+        _sample_report(),
+        context={"demo_mode": True, "analysis_mode": "Full"},
+    )
+
+    document = Document(io.BytesIO(docx_bytes))
+    text = "\n".join(paragraph.text for paragraph in document.paragraphs)
+
+    assert "Mode: Demo Mode (Full)" in text

--- a/tests/test_section_summary_concurrency.py
+++ b/tests/test_section_summary_concurrency.py
@@ -25,6 +25,7 @@ def _run_summarize_policy(
     tmp_path: Path,
     sections: dict[str, str],
     *,
+    focused: bool = False,
     persist_raw_text: bool = False,
     summarize_section: Mock | None = None,
 ) -> dict:
@@ -47,7 +48,10 @@ def _run_summarize_policy(
         )
     monkeypatch.setattr(policy_summary, "summarize_section", summarize_section)
 
-    out_path = policy_summary.summarize_policy(tmp_path / "policy.pdf")
+    out_path = policy_summary.summarize_policy(
+        tmp_path / "policy.pdf",
+        focused=focused,
+    )
 
     return json.loads(out_path.read_text(encoding="utf-8"))
 
@@ -162,6 +166,130 @@ def test_summarize_section_is_invoked_once_per_section(
     )
 
     assert summarize_section.call_count == len(sections)
+
+
+def test_full_analysis_summarizes_every_section_by_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("SECTION_SUMMARY_MAX_WORKERS", raising=False)
+    sections = {
+        "DEFINITIONS": "definition text",
+        "COVERAGE A - DWELLING": "dwelling text",
+        "UNRELATED ENDORSEMENT": "endorsement text",
+    }
+    summarize_section = Mock(
+        side_effect=lambda section_name, section_text: FakeSectionSummary(section_name)
+    )
+
+    payload = _run_summarize_policy(
+        monkeypatch,
+        tmp_path,
+        sections,
+        summarize_section=summarize_section,
+    )
+
+    assert payload["analysis_mode"] == "full"
+    assert summarize_section.call_count == len(sections)
+    assert [section["section_name"] for section in payload["sections"]] == list(
+        sections
+    )
+
+
+def test_focused_false_preserves_full_analysis_behavior(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sections = {
+        "DEFINITIONS": "definition text",
+        "COVERAGE A - DWELLING": "dwelling text",
+        "UNRELATED ENDORSEMENT": "endorsement text",
+    }
+    summarize_section = Mock(
+        side_effect=lambda section_name, section_text: FakeSectionSummary(section_name)
+    )
+
+    payload = _run_summarize_policy(
+        monkeypatch,
+        tmp_path,
+        sections,
+        focused=False,
+        summarize_section=summarize_section,
+    )
+
+    assert payload["analysis_mode"] == "full"
+    assert summarize_section.call_count == len(sections)
+
+
+def test_focused_analysis_filters_to_canonical_sections_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sections = {
+        "DEFINITIONS": "definition text",
+        "COVERAGE A - DWELLING": "dwelling text",
+        "UNRELATED ENDORSEMENT": "endorsement text",
+        "EXCLUSIONS": "exclusion text",
+    }
+    summarize_section = Mock(
+        side_effect=lambda section_name, section_text: FakeSectionSummary(section_name)
+    )
+
+    payload = _run_summarize_policy(
+        monkeypatch,
+        tmp_path,
+        sections,
+        focused=True,
+        summarize_section=summarize_section,
+    )
+
+    assert payload["analysis_mode"] == "focused"
+    assert [section["section_name"] for section in payload["sections"]] == [
+        "DEFINITIONS",
+        "COVERAGE A - DWELLING",
+        "EXCLUSIONS",
+    ]
+    assert [call.args[0] for call in summarize_section.call_args_list] == [
+        "DEFINITIONS",
+        "COVERAGE A - DWELLING",
+        "EXCLUSIONS",
+    ]
+
+
+def test_focused_analysis_skips_meta_sections(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sections = {
+        "DEFINITIONS": "This is only a sample policy and not an actual policy.",
+        "EXCLUSIONS": "We do not insure for loss caused by wear and tear.",
+    }
+
+    payload = _run_summarize_policy(
+        monkeypatch,
+        tmp_path,
+        sections,
+        focused=True,
+    )
+
+    assert [section["section_name"] for section in payload["sections"]] == [
+        "EXCLUSIONS"
+    ]
+
+
+def test_focused_selection_preserves_original_section_order() -> None:
+    sections = {
+        "COVERAGE D - LOSS OF USE": "loss of use text",
+        "UNRELATED": "unrelated text",
+        "DEFINITIONS": "definition text",
+        "COVERAGE A - DWELLING": "dwelling text",
+        "CONDITIONS": "conditions text",
+    }
+
+    focused_sections = policy_summary._select_focused_sections(sections)
+
+    assert list(focused_sections) == [
+        "COVERAGE D - LOSS OF USE",
+        "DEFINITIONS",
+        "COVERAGE A - DWELLING",
+        "CONDITIONS",
+    ]
 
 
 def test_section_summary_exception_propagates_and_writes_no_json(


### PR DESCRIPTION
Closes #52

## Summary
- Adds explicit focused-analysis mode for core policy sections.
- Preserves full analysis as the default.
- Threads focused mode through service and Streamlit UI.
- Adds analysis mode export context.
- Preserves full raw section_text_map behavior for citation/source accordions.
- Adds tests for focused filtering, forwarding, ordering, source-map preservation, and export Mode rows.

## Validation
- python -m pytest -q
- Streamlit smoke passed previously: app started on port 8502 and stopped