### PR TITLE
Sync docs after focused analysis mode

### DIFF
--- a/docs/01-current-state.md
+++ b/docs/01-current-state.md
@@ -28,6 +28,7 @@ Phase 1 is complete. The app remains a Streamlit research prototype with determi
 - PR #60: #49 stage-specific model configuration via `OPENAI_MODEL_<STAGE_UPPER>`.
 - PR #62: #50 bounded concurrency for section-summary LLM calls.
 - PR #64: #51 redundant live policy PDF reprocessing cleanup.
+- PR #66: #52 focused-analysis mode.
 
 ## Current Phase
 
@@ -41,7 +42,7 @@ Phase 1C local/demo trust polish is complete with #21 Demo Mode citation/source 
 
 #20 walkthrough video and screenshot recipe is intentionally deferred because walkthrough/video work should wait until after Phase 2 stabilizes.
 
-Phase 2 baseline benchmarking is complete via #46 / PR #54. #47 Responses API migration is complete via PR #56. #48 Structured Outputs is complete via PR #58 for final dispute report generation only. #49 stage-specific model configuration is complete via PR #60. #50 section-summary latency reduction is complete via PR #62. #51 redundant live policy PDF reprocessing cleanup is complete via PR #64.
+Phase 2 baseline benchmarking is complete via #46 / PR #54. #47 Responses API migration is complete via PR #56. #48 Structured Outputs is complete via PR #58 for final dispute report generation only. #49 stage-specific model configuration is complete via PR #60. #50 section-summary latency reduction is complete via PR #62. #51 redundant live policy PDF reprocessing cleanup is complete via PR #64. #52 focused-analysis mode is complete via PR #66.
 
 Stage-specific model overrides are available through `OPENAI_MODEL_<STAGE_UPPER>`, such as `OPENAI_MODEL_SECTION_SUMMARY` and `OPENAI_MODEL_DISPUTE_REPORT`. Default model behavior is unchanged unless a per-stage override is explicitly set.
 
@@ -49,7 +50,11 @@ Section summaries intentionally remain on the default `json_object` mode. Sectio
 
 PR #64 removed live policy PDF reprocessing by reusing the first-pass raw sections for the in-memory citation source map. `section_text_map` is stripped before claim persistence to avoid persisting raw policy text with saved claims.
 
-The next intended issue is #52 focused-analysis mode. Do not start #52 as part of post-#64 hygiene; no focused-analysis mode, prompt changes, dataclass/schema refactors, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, benchmark changes, deployment/auth/storage work, or PDF export work have started.
+PR #66 added explicit opt-in focused-analysis mode. Full analysis remains the default. Focused mode filters policy sections before section-summary LLM calls to a canonical core-section allowlist: `DEFINITIONS`, `EXCLUSIONS`, `CONDITIONS`, `COVERAGE A - DWELLING`, `COVERAGE B - OTHER STRUCTURES`, `COVERAGE C - PERSONAL PROPERTY`, and `COVERAGE D - LOSS OF USE`. Focused mode skips obvious meta sections. It did not change prompts, report schemas/dataclasses, Structured Outputs behavior, model defaults, or stage-specific model config. Section-summary concurrency behavior is unchanged except that focused mode filters the input section list before `executor.map`.
+
+Focused mode preserves citation/source accordion behavior: `section_text_map` still comes from full raw sections, while raw policy section text is still stripped before claim persistence. Export context now includes a Mode row, including Demo Mode plus Focused/Full combinations. PR #66 validation: `python -m pytest -q` passed with 85 tests.
+
+Phase 2 is complete through #52. The next intended issue is #53 P2-7 Add final Phase 2 benchmark comparison report. Do not start #53 as part of post-#52 docs sync.
 
 ## Local Cleanup
 

--- a/docs/03-roadmap.md
+++ b/docs/03-roadmap.md
@@ -32,13 +32,13 @@ Intentionally deferred:
 - #18 Streamlit Community Cloud deployment prep - revisit only when a hosted public demo is needed.
 - #20 walkthrough video/screenshot recipe - revisit after Phase 2 stabilizes.
 
-## Phase 2: Model and speed refactor - PDF reprocessing cleanup complete
+## Phase 2: Model and speed refactor - focused-analysis mode complete
 
-True Phase 2 remains reserved for model/speed/API refactor work. Baseline measurement is complete via #46 / PR #54. The Responses API migration is complete via #47 / PR #56. Structured Outputs for final dispute report generation is complete via #48 / PR #58. Stage-specific model configuration is complete via #49 / PR #60. Section-summary latency reduction is complete via #50 / PR #62. Redundant live policy PDF reprocessing cleanup is complete via #51 / PR #64. The next intended issue is #52 focused-analysis mode.
+True Phase 2 remains reserved for model/speed/API refactor work. Baseline measurement is complete via #46 / PR #54. The Responses API migration is complete via #47 / PR #56. Structured Outputs for final dispute report generation is complete via #48 / PR #58. Stage-specific model configuration is complete via #49 / PR #60. Section-summary latency reduction is complete via #50 / PR #62. Redundant live policy PDF reprocessing cleanup is complete via #51 / PR #64. Focused-analysis mode is complete via #52 / PR #66. The next intended issue is #53 P2-7 Add final Phase 2 benchmark comparison report.
 
 Gating rule:
 
-#50 added bounded concurrency for section-summary LLM calls only. Section-summary calls now use `ThreadPoolExecutor`; `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior. #51 removed the second live policy PDF pass by reusing first-pass raw sections for the in-memory citation source map, and `section_text_map` is stripped before claim persistence to avoid raw policy text persistence. Do not bundle prompt rewrites, report schema changes, benchmark changes, model swaps, or unrelated refactors into #52.
+#50 added bounded concurrency for section-summary LLM calls only. Section-summary calls now use `ThreadPoolExecutor`; `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior. #51 removed the second live policy PDF pass by reusing first-pass raw sections for the in-memory citation source map, and `section_text_map` is stripped before claim persistence to avoid raw policy text persistence. #52 added explicit opt-in focused-analysis mode while preserving full analysis as the default. Focused mode filters policy sections before section-summary LLM calls to the canonical core allowlist (`DEFINITIONS`, `EXCLUSIONS`, `CONDITIONS`, `COVERAGE A - DWELLING`, `COVERAGE B - OTHER STRUCTURES`, `COVERAGE C - PERSONAL PROPERTY`, `COVERAGE D - LOSS OF USE`) and skips obvious meta sections. It did not change prompts, report schemas/dataclasses, Structured Outputs behavior, model defaults, stage-specific model configuration, or section-summary concurrency behavior beyond filtering the input section list before `executor.map`. `section_text_map` still comes from full raw sections for citation/source accordions, and raw policy section text is still not persisted. Export context includes Mode, including Demo Mode plus Focused/Full combinations. Do not bundle benchmark comparison work or unrelated refactors into post-#52 docs sync.
 
 Order:
 
@@ -49,8 +49,8 @@ Order:
 4. Add stage-specific model configuration: complete via #49 / PR #60.
 5. Parallelize per-section LLM calls: complete via #50 / PR #62.
 6. Remove redundant PDF reprocessing in the live pipeline: complete via #51 / PR #64.
-7. Add focused-analysis mode: next via #52.
-8. Final benchmark report comparing latency, cost, and report quality against the Phase 2 baseline.
+7. Add focused-analysis mode: complete via #52 / PR #66.
+8. Final benchmark report comparing latency, cost, and report quality against the Phase 2 baseline: next via #53.
 
 ## Out of scope across all phases
 

--- a/docs/06-heartbeat.md
+++ b/docs/06-heartbeat.md
@@ -1,6 +1,6 @@
 # Heartbeat
 
-Last updated: 2026-04-26 00:27 ET
+Last updated: 2026-04-26 post-#52 docs sync
 
 ## Current Phase
 - Phase 1 is complete: Phase 1A demo polish, Phase 1B technical closeout, and Phase 1C local/demo trust polish.
@@ -10,6 +10,7 @@ Last updated: 2026-04-26 00:27 ET
 - Phase 2 stage-specific model configuration is complete via #49 / PR #60.
 - Phase 2 section-summary latency reduction is complete via #50 / PR #62.
 - Phase 2 redundant live policy PDF reprocessing cleanup is complete via #51 / PR #64.
+- Phase 2 focused-analysis mode is complete via #52 / PR #66.
 
 ## Current Truth
 - PR #44 wrapped Phase 1 and handed off to Phase 2 baseline benchmarking.
@@ -20,6 +21,14 @@ Last updated: 2026-04-26 00:27 ET
 - PR #62 added bounded concurrency for section-summary LLM calls using `ThreadPoolExecutor`. `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior.
 - PR #64 removed live policy PDF reprocessing by reusing first-pass raw sections for the in-memory citation source map.
 - PR #64 strips `section_text_map` before claim persistence to avoid persisting raw policy text.
+- PR #66 added explicit opt-in focused-analysis mode. Full analysis remains the default.
+- Focused mode filters policy sections before section-summary LLM calls to the canonical core allowlist: `DEFINITIONS`, `EXCLUSIONS`, `CONDITIONS`, `COVERAGE A - DWELLING`, `COVERAGE B - OTHER STRUCTURES`, `COVERAGE C - PERSONAL PROPERTY`, and `COVERAGE D - LOSS OF USE`.
+- Focused mode skips obvious meta sections.
+- PR #66 did not change prompts, report schemas/dataclasses, Structured Outputs behavior, model defaults, or stage-specific model config.
+- Section-summary concurrency behavior remains unchanged except that focused mode filters the input section list before `executor.map`.
+- `section_text_map` still comes from full raw sections, preserving citation/source accordion behavior, and raw policy section text is still not persisted.
+- Export context now includes Mode, including Demo Mode plus Focused/Full combinations.
+- PR #66 validation: `python -m pytest -q` passed with 85 tests.
 - The checked-in baseline is deterministic demo-bundle mode with no API calls.
 - #21 Demo Mode citation/source accordions are complete via PR #41.
 - Demo source-map loading hardening is complete via PR #42.
@@ -27,7 +36,7 @@ Last updated: 2026-04-26 00:27 ET
 - The repo remains a research prototype with AI-generated and not-legal-advice framing.
 
 ## Next Action
-- Start #52 focused-analysis mode only. Do not bundle prompt rewrites, report schema changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, benchmark changes, deployment/auth/storage work, PDF export work, or unrelated refactors.
+- Start #53 P2-7 Add final Phase 2 benchmark comparison report. Do not bundle prompt rewrites, report schema changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, deployment/auth/storage work, PDF export work, or unrelated refactors.
 
 ## Deferred
 - #18 Streamlit deployment prep — deferred because hosted deployment is not needed yet and adds surface area.
@@ -35,11 +44,12 @@ Last updated: 2026-04-26 00:27 ET
 
 ## Watchouts
 - #46 baseline benchmarking is complete; use it as the before-state reference for remaining Phase 2 work.
-- #47 Responses API migration is complete; do not re-open API migration work while starting #52.
-- #48 Structured Outputs is complete for final dispute report generation only; do not expand it while starting #52.
-- #49 stage-specific model configuration is complete; do not tune model choices by default while starting #52.
-- #50 section-summary concurrency is complete; do not rework prompts, schemas, model configuration, retry behavior, telemetry, or benchmark code while starting #52.
-- #51 redundant live policy PDF reprocessing cleanup is complete; do not re-open PDF processing while starting #52.
+- #47 Responses API migration is complete; do not re-open API migration work while starting #53.
+- #48 Structured Outputs is complete for final dispute report generation only; do not expand it while starting #53.
+- #49 stage-specific model configuration is complete; do not tune model choices by default while starting #53.
+- #50 section-summary concurrency is complete; do not rework prompts, schemas, model configuration, retry behavior, telemetry, or benchmark code while starting #53.
+- #51 redundant live policy PDF reprocessing cleanup is complete; do not re-open PDF processing while starting #53.
+- #52 focused-analysis mode is complete; do not re-open filtering, prompt, schema, model, or citation/source accordion behavior while starting #53.
 - Section summaries remain on `json_object` mode unless a later issue explicitly changes that.
 - Section-summary calls use bounded `ThreadPoolExecutor` concurrency; keep `SECTION_SUMMARY_MAX_WORKERS=1` as the sequential kill-switch.
 - The live citation source map reuses first-pass raw sections in memory; `section_text_map` is stripped before claim persistence.

--- a/docs/08-memory.md
+++ b/docs/08-memory.md
@@ -14,12 +14,16 @@ Durable project timeline for future Codex and Claude sessions.
 - Phase 2 stage-specific model configuration is complete via #49 / PR #60.
 - Phase 2 section-summary latency reduction is complete via #50 / PR #62.
 - Phase 2 redundant live policy PDF reprocessing cleanup is complete via #51 / PR #64.
+- Phase 2 focused-analysis mode is complete via #52 / PR #66.
 - Stage-specific model overrides use `OPENAI_MODEL_<STAGE_UPPER>` and default model behavior is unchanged unless a per-stage override is explicitly set.
 - Section summaries intentionally remain on default `json_object` mode.
 - Section-summary calls now use bounded concurrency via `ThreadPoolExecutor`. `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior.
 - #51 removed live policy PDF reprocessing by reusing first-pass raw sections for the in-memory citation source map.
 - `section_text_map` is stripped before claim persistence to avoid raw policy text persistence.
-- Next: start #52 focused-analysis mode only. Do not bundle prompt rewrites, report schema changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, benchmark changes, deployment/auth/storage work, PDF export work, or unrelated refactors in the #52 PR.
+- #52 added explicit opt-in focused-analysis mode. Full analysis remains the default. Focused mode filters policy sections before section-summary LLM calls to a canonical core-section allowlist (`DEFINITIONS`, `EXCLUSIONS`, `CONDITIONS`, `COVERAGE A - DWELLING`, `COVERAGE B - OTHER STRUCTURES`, `COVERAGE C - PERSONAL PROPERTY`, `COVERAGE D - LOSS OF USE`) and skips obvious meta sections.
+- #52 did not change prompts, report schemas/dataclasses, Structured Outputs behavior, model defaults, stage-specific model config, or section-summary concurrency behavior beyond filtering the input section list before `executor.map`.
+- #52 preserves citation/source accordions because `section_text_map` still comes from full raw sections. Raw policy section text is still not persisted. Export context now includes Mode, including Demo Mode plus Focused/Full combinations.
+- Next: start #53 P2-7 Add final Phase 2 benchmark comparison report only. Do not bundle prompt rewrites, report schema changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, deployment/auth/storage work, PDF export work, or unrelated refactors in the #53 PR.
 
 ## Timeline
 
@@ -38,6 +42,7 @@ Durable project timeline for future Codex and Claude sessions.
 | 2026-04-25 23:37 ET | Stage-specific model configuration merged | #49 / PR #60 | Added optional `OPENAI_MODEL_<STAGE_UPPER>` overrides while preserving default model behavior unless explicitly configured. |
 | 2026-04-25 23:58 ET | Section-summary concurrency merged | #50 / PR #62 | Added bounded `ThreadPoolExecutor` concurrency for section-summary LLM calls; `SECTION_SUMMARY_MAX_WORKERS=1` remains the sequential kill-switch. |
 | 2026-04-26 00:25 ET | Redundant live policy PDF reprocessing cleanup merged | #51 / PR #64 | Reuses first-pass raw sections for the in-memory citation source map and strips `section_text_map` before claim persistence to avoid raw policy text persistence. |
+| 2026-04-26 | Focused-analysis mode merged | #52 / PR #66 | Added explicit opt-in focused mode for canonical core policy sections while preserving full analysis as the default and keeping citation/source accordions backed by full raw sections. |
 
 ## Standing Guardrails
 

--- a/docs/09-session-log.md
+++ b/docs/09-session-log.md
@@ -256,3 +256,34 @@ Track real working sessions so future AI/dev sessions can quickly understand wha
 
 #### Next session starter
 - Start #52 only: focused-analysis mode, without prompt rewrites, schema/dataclass changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, benchmark changes, deployment/auth/storage work, PDF export work, or unrelated refactors.
+
+### 2026-04-26 - Post-#66 hygiene truth sync
+
+#### Goal
+- Confirm #52 / PR #66 post-merge state and align durable docs with #53 as the next intended issue.
+
+#### Completed
+- Confirmed PR #66 is merged and #52 focused-analysis mode is complete.
+- Updated durable docs to mark Phase 2 complete through #52.
+- Recorded that focused-analysis mode is explicit opt-in and full analysis remains the default.
+- Recorded that focused mode filters policy sections before section-summary LLM calls to the canonical core-section allowlist: `DEFINITIONS`, `EXCLUSIONS`, `CONDITIONS`, `COVERAGE A - DWELLING`, `COVERAGE B - OTHER STRUCTURES`, `COVERAGE C - PERSONAL PROPERTY`, and `COVERAGE D - LOSS OF USE`.
+- Recorded that focused mode skips obvious meta sections.
+- Recorded that PR #66 did not change prompts, report schemas/dataclasses, Structured Outputs behavior, model defaults, or stage-specific model config.
+- Recorded that section-summary concurrency behavior remains unchanged except focused mode filters the input section list before `executor.map`.
+- Recorded that `section_text_map` still comes from full raw sections for citation/source accordions and raw policy section text is still not persisted.
+- Recorded that export context includes Mode, including Demo Mode plus Focused/Full combinations.
+
+#### Decisions
+- No new technical decisions.
+- No decision-log update because there is no existing Phase 2 decision-log pattern for this kind of post-merge truth sync.
+
+#### Validation
+- PR #66 validation: `python -m pytest -q` passed with 85 tests.
+- This PR is docs-only; tests were not run for the docs sync.
+
+#### Deferred
+- #53 P2-7 Add final Phase 2 benchmark comparison report remains deferred to the next issue.
+- Prompt rewrites, schema/dataclass changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, deployment/auth/storage work, PDF export work, and unrelated refactors remain out of scope.
+
+#### Next session starter
+- Start #53 only: final Phase 2 benchmark comparison report, without prompt rewrites, schema/dataclass changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, deployment/auth/storage work, PDF export work, or unrelated refactors.


### PR DESCRIPTION
## Summary
- Marks #52 / PR #66 focused-analysis mode complete.
- Documents focused mode behavior and preserved full-analysis defaults.
- Records validation and next Phase 2 step: #53 benchmark comparison report.

## Validation
- Docs-only change
- Not run: documentation-only update