### PR TITLE
Add final Phase 2 benchmark comparison report

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ python scripts/benchmark_phase2_baseline.py --mode live \
 
 See `benchmarks/phase2-baseline.md` for the checked-in before-state report and limitations.
 
+The final Phase 2 comparison report is `benchmarks/phase2-final.md`. It keeps the baseline report historical, records the current no-API demo parity check, and documents current live full-vs-focused benchmark results when available.
+
 ### Summarize a policy PDF
 
 ```bash

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -66,6 +66,12 @@ Do not rebuild this bundle from real client claim data.
 - Phase 2 live pipeline benchmark (requires `OPENAI_API_KEY` and non-sensitive local inputs):
   - `python scripts/benchmark_phase2_baseline.py --mode live --policy-pdf data/raw_policies/HO3_TRUE_FL_2021.pdf --denial-text data/raw_denials/HO3_TRUE_FL_2021_denial.txt --output .tmp/phase2-baseline-live.json`
 
+- Phase 2 live focused benchmark (requires `OPENAI_API_KEY` and non-sensitive local inputs):
+  - `python scripts/benchmark_phase2_baseline.py --mode live --focused --policy-pdf data/raw_policies/HO3_TRUE_FL_2021.pdf --denial-text data/raw_denials/HO3_TRUE_FL_2021_denial.txt --output .tmp/phase2-final-live-focused.json`
+
+- Final Phase 2 benchmark comparison:
+  - See `benchmarks/phase2-final.md`
+
 - CLI (optional):
   - `python -m src.run_baseline_policy_summary path/to/policy.pdf`
   - `python -m src.run_denial_summary data/processed/policy.json path/to/denial.txt`

--- a/benchmarks/phase2-final.md
+++ b/benchmarks/phase2-final.md
@@ -1,0 +1,144 @@
+# Phase 2 Final Benchmark Comparison
+
+Date: 2026-04-26
+
+This is the final Phase 2 comparison report for #53. It preserves the historical before-state report at `benchmarks/phase2-baseline.md` and records current measurements after the Phase 2 model/API/speed sprint.
+
+## Scope
+
+Phase 2 completed:
+
+- #46 / PR #54: baseline benchmark harness and checked-in no-API baseline report.
+- #47 / PR #56: Responses API migration.
+- #48 / PR #58: Structured Outputs for final dispute report generation only.
+- #49 / PR #60: stage-specific model configuration.
+- #50 / PR #62: bounded section-summary concurrency.
+- #51 / PR #64: redundant live policy PDF reprocessing removed.
+- #52 / PR #66: focused-analysis mode.
+
+No prompts, report schemas/dataclasses, model defaults, stage-specific model defaults, focused-analysis behavior, section-summary concurrency behavior, citation/source accordion behavior, token/cost telemetry, quality scoring harnesses, deployment, auth, storage, or PDF export behavior were changed for this final report.
+
+## Historical Baseline Reference
+
+The Phase 2 before-state report remains `benchmarks/phase2-baseline.md`.
+
+That baseline was intentionally deterministic and offline:
+
+- Command: `python scripts/benchmark_phase2_baseline.py --mode demo`
+- API calls made: no
+- Input: checked-in demo bundle under `assets/demo/`
+- Total wall-clock runtime: 0.0024 seconds
+- Demo citations: 23
+- Linked demo citations: 23
+- Rendered Markdown characters: 5,895
+
+The baseline did not measure PDF extraction, policy sectioning, OpenAI latency, token usage, cost, live denial-aware report generation, or Streamlit browser rendering.
+
+## Current Demo-Bundle Parity
+
+Current run:
+
+```bash
+python scripts/benchmark_phase2_baseline.py --mode demo --output .tmp/phase2-final-demo.json
+```
+
+Result on 2026-04-26:
+
+| Metric | Historical baseline | Current rerun |
+| --- | ---: | ---: |
+| API calls made | no | no |
+| Total wall-clock runtime | 0.0024 seconds | 0.0437 seconds |
+| Demo citations | 23 | 23 |
+| Linked demo citations | 23 | 23 |
+| Rendered Markdown characters | 5,895 | 5,895 |
+| Demo source-map entries | 13 | 13 |
+
+Current stage timings:
+
+| Stage | Wall-clock seconds |
+| --- | ---: |
+| `load_demo_assets` | 0.0417 |
+| `build_dispute_report_object` | 0.0001 |
+| `render_dispute_markdown` | 0.0002 |
+| `link_demo_citations` | 0.0016 |
+
+Interpretation: the deterministic demo output shape is preserved. Citation totals, linked citation totals, rendered Markdown length, and stage coverage match the before-state expectations. The wall-clock number is local filesystem/runtime noise and is not a live model latency measurement.
+
+## Current Live Full Analysis
+
+Current run:
+
+```bash
+python scripts/benchmark_phase2_baseline.py --mode live \
+  --policy-pdf data/raw_policies/HO3_TRUE_FL_2021.pdf \
+  --denial-text data/raw_denials/HO3_TRUE_FL_2021_denial.txt \
+  --output .tmp/phase2-final-live-full.json
+```
+
+Result on 2026-04-26:
+
+| Metric | Value |
+| --- | ---: |
+| API calls made | yes |
+| Analysis mode | full |
+| Total wall-clock runtime | 83.3361 seconds |
+| Policy summary pipeline | 48.5842 seconds |
+| Denial/dispute pipeline | 34.6988 seconds |
+| Summarized policy sections | 25 |
+
+Token usage and cost remain `null` in the checked-in benchmark payload because the benchmark harness does not add token/cost telemetry.
+
+## Current Live Focused Analysis
+
+Current run:
+
+```bash
+python scripts/benchmark_phase2_baseline.py --mode live --focused \
+  --policy-pdf data/raw_policies/HO3_TRUE_FL_2021.pdf \
+  --denial-text data/raw_denials/HO3_TRUE_FL_2021_denial.txt \
+  --output .tmp/phase2-final-live-focused.json
+```
+
+Result on 2026-04-26:
+
+| Metric | Value |
+| --- | ---: |
+| API calls made | yes |
+| Analysis mode | focused |
+| Total wall-clock runtime | 32.0213 seconds |
+| Policy summary pipeline | 12.4485 seconds |
+| Denial/dispute pipeline | 19.5184 seconds |
+| Summarized policy sections | 4 |
+
+The focused run summarized these current fixture sections:
+
+- `DEFINITIONS`
+- `CONDITIONS`
+- `COVERAGE C - PERSONAL PROPERTY`
+- `EXCLUSIONS`
+
+## Current Full vs Focused Comparison
+
+| Metric | Full | Focused | Change |
+| --- | ---: | ---: | ---: |
+| Summarized policy sections | 25 | 4 | 84.0% fewer |
+| Total wall-clock runtime | 83.3361s | 32.0213s | 61.6% lower |
+| Policy summary pipeline | 48.5842s | 12.4485s | 74.4% lower |
+| Denial/dispute pipeline | 34.6988s | 19.5184s | 43.7% lower |
+
+Interpretation: focused mode materially reduces section-summary work for this fixture by filtering the policy summary input before LLM section-summary calls. The dispute stage also ran faster in this single live comparison because it received a smaller policy-summary payload.
+
+## Limitations
+
+- No pre-Phase-2 live baseline was captured. The historical baseline is a deterministic no-API demo benchmark, not a live model/API benchmark.
+- Token usage and cost are not captured in checked-in benchmark artifacts.
+- The live full/focused results are a single-fixture local measurement and should not be generalized as a production latency guarantee.
+- No A-G quality scoring or evaluation harness was added.
+- The live benchmark writes local runtime artifacts under `data/processed`; those outputs are not part of this report and should not be committed.
+- W&B may record telemetry if enabled in the local environment, but W&B output is not used as a checked-in benchmark source here.
+
+## Final Recommendation
+
+Phase 2 achieved the intended modernization and performance work without changing prompts, schemas, product scope, or deployment posture. The app now uses the Responses API, strict Structured Outputs for final dispute reports, optional stage-specific model overrides, bounded section-summary concurrency, one-pass live PDF section reuse for citation/source support, and explicit opt-in focused analysis.
+
+Stop Phase 2 after #53. Consider #18 Streamlit deployment prep and #20 walkthrough/screenshot recipe later as separate, post-Phase-2 work.

--- a/docs/01-current-state.md
+++ b/docs/01-current-state.md
@@ -29,6 +29,7 @@ Phase 1 is complete. The app remains a Streamlit research prototype with determi
 - PR #62: #50 bounded concurrency for section-summary LLM calls.
 - PR #64: #51 redundant live policy PDF reprocessing cleanup.
 - PR #66: #52 focused-analysis mode.
+- #53: final Phase 2 benchmark comparison report.
 
 ## Current Phase
 
@@ -42,7 +43,7 @@ Phase 1C local/demo trust polish is complete with #21 Demo Mode citation/source 
 
 #20 walkthrough video and screenshot recipe is intentionally deferred because walkthrough/video work should wait until after Phase 2 stabilizes.
 
-Phase 2 baseline benchmarking is complete via #46 / PR #54. #47 Responses API migration is complete via PR #56. #48 Structured Outputs is complete via PR #58 for final dispute report generation only. #49 stage-specific model configuration is complete via PR #60. #50 section-summary latency reduction is complete via PR #62. #51 redundant live policy PDF reprocessing cleanup is complete via PR #64. #52 focused-analysis mode is complete via PR #66.
+Phase 2 baseline benchmarking is complete via #46 / PR #54. #47 Responses API migration is complete via PR #56. #48 Structured Outputs is complete via PR #58 for final dispute report generation only. #49 stage-specific model configuration is complete via PR #60. #50 section-summary latency reduction is complete via PR #62. #51 redundant live policy PDF reprocessing cleanup is complete via PR #64. #52 focused-analysis mode is complete via PR #66. #53 final Phase 2 benchmark comparison reporting is complete.
 
 Stage-specific model overrides are available through `OPENAI_MODEL_<STAGE_UPPER>`, such as `OPENAI_MODEL_SECTION_SUMMARY` and `OPENAI_MODEL_DISPUTE_REPORT`. Default model behavior is unchanged unless a per-stage override is explicitly set.
 
@@ -54,7 +55,9 @@ PR #66 added explicit opt-in focused-analysis mode. Full analysis remains the de
 
 Focused mode preserves citation/source accordion behavior: `section_text_map` still comes from full raw sections, while raw policy section text is still stripped before claim persistence. Export context now includes a Mode row, including Demo Mode plus Focused/Full combinations. PR #66 validation: `python -m pytest -q` passed with 85 tests.
 
-Phase 2 is complete through #52. The next intended issue is #53 P2-7 Add final Phase 2 benchmark comparison report. Do not start #53 as part of post-#52 docs sync.
+The final Phase 2 benchmark comparison report is `benchmarks/phase2-final.md`. It keeps `benchmarks/phase2-baseline.md` as the historical before-state, records deterministic demo parity, current live full/focused measurements for the HO3 TRUE FL fixture, and documents limitations around live baselines, token/cost telemetry, and quality scoring.
+
+Phase 2 is complete through #53. #18 Streamlit Community Cloud deployment prep and #20 walkthrough/video recipe remain deferred post-Phase-2 work.
 
 ## Local Cleanup
 

--- a/docs/03-roadmap.md
+++ b/docs/03-roadmap.md
@@ -32,13 +32,13 @@ Intentionally deferred:
 - #18 Streamlit Community Cloud deployment prep - revisit only when a hosted public demo is needed.
 - #20 walkthrough video/screenshot recipe - revisit after Phase 2 stabilizes.
 
-## Phase 2: Model and speed refactor - focused-analysis mode complete
+## Phase 2: Model and speed refactor - complete
 
-True Phase 2 remains reserved for model/speed/API refactor work. Baseline measurement is complete via #46 / PR #54. The Responses API migration is complete via #47 / PR #56. Structured Outputs for final dispute report generation is complete via #48 / PR #58. Stage-specific model configuration is complete via #49 / PR #60. Section-summary latency reduction is complete via #50 / PR #62. Redundant live policy PDF reprocessing cleanup is complete via #51 / PR #64. Focused-analysis mode is complete via #52 / PR #66. The next intended issue is #53 P2-7 Add final Phase 2 benchmark comparison report.
+True Phase 2 remains reserved for model/speed/API refactor work. Baseline measurement is complete via #46 / PR #54. The Responses API migration is complete via #47 / PR #56. Structured Outputs for final dispute report generation is complete via #48 / PR #58. Stage-specific model configuration is complete via #49 / PR #60. Section-summary latency reduction is complete via #50 / PR #62. Redundant live policy PDF reprocessing cleanup is complete via #51 / PR #64. Focused-analysis mode is complete via #52 / PR #66. Final benchmark comparison reporting is complete via #53.
 
 Gating rule:
 
-#50 added bounded concurrency for section-summary LLM calls only. Section-summary calls now use `ThreadPoolExecutor`; `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior. #51 removed the second live policy PDF pass by reusing first-pass raw sections for the in-memory citation source map, and `section_text_map` is stripped before claim persistence to avoid raw policy text persistence. #52 added explicit opt-in focused-analysis mode while preserving full analysis as the default. Focused mode filters policy sections before section-summary LLM calls to the canonical core allowlist (`DEFINITIONS`, `EXCLUSIONS`, `CONDITIONS`, `COVERAGE A - DWELLING`, `COVERAGE B - OTHER STRUCTURES`, `COVERAGE C - PERSONAL PROPERTY`, `COVERAGE D - LOSS OF USE`) and skips obvious meta sections. It did not change prompts, report schemas/dataclasses, Structured Outputs behavior, model defaults, stage-specific model configuration, or section-summary concurrency behavior beyond filtering the input section list before `executor.map`. `section_text_map` still comes from full raw sections for citation/source accordions, and raw policy section text is still not persisted. Export context includes Mode, including Demo Mode plus Focused/Full combinations. Do not bundle benchmark comparison work or unrelated refactors into post-#52 docs sync.
+#50 added bounded concurrency for section-summary LLM calls only. Section-summary calls now use `ThreadPoolExecutor`; `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior. #51 removed the second live policy PDF pass by reusing first-pass raw sections for the in-memory citation source map, and `section_text_map` is stripped before claim persistence to avoid raw policy text persistence. #52 added explicit opt-in focused-analysis mode while preserving full analysis as the default. Focused mode filters policy sections before section-summary LLM calls to the canonical core allowlist (`DEFINITIONS`, `EXCLUSIONS`, `CONDITIONS`, `COVERAGE A - DWELLING`, `COVERAGE B - OTHER STRUCTURES`, `COVERAGE C - PERSONAL PROPERTY`, `COVERAGE D - LOSS OF USE`) and skips obvious meta sections. It did not change prompts, report schemas/dataclasses, Structured Outputs behavior, model defaults, stage-specific model configuration, or section-summary concurrency behavior beyond filtering the input section list before `executor.map`. `section_text_map` still comes from full raw sections for citation/source accordions, and raw policy section text is still not persisted. Export context includes Mode, including Demo Mode plus Focused/Full combinations. #53 added `benchmarks/phase2-final.md` and a live-only focused benchmark flag for current full-vs-focused comparison without changing default benchmark or app behavior.
 
 Order:
 
@@ -50,7 +50,9 @@ Order:
 5. Parallelize per-section LLM calls: complete via #50 / PR #62.
 6. Remove redundant PDF reprocessing in the live pipeline: complete via #51 / PR #64.
 7. Add focused-analysis mode: complete via #52 / PR #66.
-8. Final benchmark report comparing latency, cost, and report quality against the Phase 2 baseline: next via #53.
+8. Final benchmark report comparing deterministic demo parity and current live full/focused behavior: complete via #53.
+
+Phase 2 is now closed. Revisit #18 Streamlit Community Cloud deployment prep and #20 walkthrough/screenshot recipe as separate post-Phase-2 work only when needed.
 
 ## Out of scope across all phases
 

--- a/docs/05-decision-log.md
+++ b/docs/05-decision-log.md
@@ -99,3 +99,21 @@ Use this format for future entries:
 
 ### Revisit trigger
 - Revisit #18 only when a hosted public demo is needed; revisit #20 after Phase 2 stabilizes.
+
+## 2026-04-26 ET - Close Phase 2 with separate final benchmark report
+
+### Context
+- #46 created a historical before-state benchmark report before Phase 2 model/API/speed work.
+- #53 needed a final comparison without rewriting that baseline history or expanding product scope.
+
+### Decision
+- Keep `benchmarks/phase2-baseline.md` as the immutable historical before-state.
+- Add final comparison in a separate `benchmarks/phase2-final.md`.
+- Close Phase 2 after #53.
+
+### Consequence
+- Future benchmark follow-ups should start from a new issue rather than editing the Phase 2 baseline.
+- Post-Phase-2 work such as #18 deployment prep and #20 walkthrough/screenshot recipe stays separate.
+
+### Revisit trigger
+- Revisit only if a later benchmark issue adds a new measurement scope, telemetry source, or evaluation harness.

--- a/docs/06-heartbeat.md
+++ b/docs/06-heartbeat.md
@@ -1,6 +1,6 @@
 # Heartbeat
 
-Last updated: 2026-04-26 post-#52 docs sync
+Last updated: 2026-04-26 post-#53 final benchmark report
 
 ## Current Phase
 - Phase 1 is complete: Phase 1A demo polish, Phase 1B technical closeout, and Phase 1C local/demo trust polish.
@@ -11,6 +11,7 @@ Last updated: 2026-04-26 post-#52 docs sync
 - Phase 2 section-summary latency reduction is complete via #50 / PR #62.
 - Phase 2 redundant live policy PDF reprocessing cleanup is complete via #51 / PR #64.
 - Phase 2 focused-analysis mode is complete via #52 / PR #66.
+- Phase 2 final benchmark comparison reporting is complete via #53.
 
 ## Current Truth
 - PR #44 wrapped Phase 1 and handed off to Phase 2 baseline benchmarking.
@@ -30,26 +31,28 @@ Last updated: 2026-04-26 post-#52 docs sync
 - Export context now includes Mode, including Demo Mode plus Focused/Full combinations.
 - PR #66 validation: `python -m pytest -q` passed with 85 tests.
 - The checked-in baseline is deterministic demo-bundle mode with no API calls.
+- The final Phase 2 comparison is `benchmarks/phase2-final.md`; it preserves `benchmarks/phase2-baseline.md` as the historical before-state and records current demo parity plus full/focused live measurements for the HO3 TRUE FL fixture.
 - #21 Demo Mode citation/source accordions are complete via PR #41.
 - Demo source-map loading hardening is complete via PR #42.
 - #23 human-readable export context and human/AI export grouping are complete via PR #43.
 - The repo remains a research prototype with AI-generated and not-legal-advice framing.
 
 ## Next Action
-- Start #53 P2-7 Add final Phase 2 benchmark comparison report. Do not bundle prompt rewrites, report schema changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, deployment/auth/storage work, PDF export work, or unrelated refactors.
+- Phase 2 is closed after #53. Consider #18 Streamlit deployment prep or #20 walkthrough/video recipe later as separate post-Phase-2 work only when needed.
 
 ## Deferred
 - #18 Streamlit deployment prep — deferred because hosted deployment is not needed yet and adds surface area.
 - #20 walkthrough/video recipe — deferred until after Phase 2 model/API/speed upgrades stabilize.
 
 ## Watchouts
-- #46 baseline benchmarking is complete; use it as the before-state reference for remaining Phase 2 work.
+- #46 baseline benchmarking is complete; keep `benchmarks/phase2-baseline.md` as the before-state reference.
 - #47 Responses API migration is complete; do not re-open API migration work while starting #53.
 - #48 Structured Outputs is complete for final dispute report generation only; do not expand it while starting #53.
 - #49 stage-specific model configuration is complete; do not tune model choices by default while starting #53.
 - #50 section-summary concurrency is complete; do not rework prompts, schemas, model configuration, retry behavior, telemetry, or benchmark code while starting #53.
 - #51 redundant live policy PDF reprocessing cleanup is complete; do not re-open PDF processing while starting #53.
-- #52 focused-analysis mode is complete; do not re-open filtering, prompt, schema, model, or citation/source accordion behavior while starting #53.
+- #52 focused-analysis mode is complete; do not re-open filtering, prompt, schema, model, or citation/source accordion behavior after #53.
+- #53 final reporting is complete; do not add token/cost telemetry or a quality scoring harness unless a later issue explicitly asks for it.
 - Section summaries remain on `json_object` mode unless a later issue explicitly changes that.
 - Section-summary calls use bounded `ThreadPoolExecutor` concurrency; keep `SECTION_SUMMARY_MAX_WORKERS=1` as the sequential kill-switch.
 - The live citation source map reuses first-pass raw sections in memory; `section_text_map` is stripped before claim persistence.

--- a/docs/08-memory.md
+++ b/docs/08-memory.md
@@ -15,6 +15,7 @@ Durable project timeline for future Codex and Claude sessions.
 - Phase 2 section-summary latency reduction is complete via #50 / PR #62.
 - Phase 2 redundant live policy PDF reprocessing cleanup is complete via #51 / PR #64.
 - Phase 2 focused-analysis mode is complete via #52 / PR #66.
+- Phase 2 final benchmark comparison reporting is complete via #53.
 - Stage-specific model overrides use `OPENAI_MODEL_<STAGE_UPPER>` and default model behavior is unchanged unless a per-stage override is explicitly set.
 - Section summaries intentionally remain on default `json_object` mode.
 - Section-summary calls now use bounded concurrency via `ThreadPoolExecutor`. `SECTION_SUMMARY_MAX_WORKERS` defaults to 4, and `SECTION_SUMMARY_MAX_WORKERS=1` forces sequential behavior.
@@ -23,7 +24,8 @@ Durable project timeline for future Codex and Claude sessions.
 - #52 added explicit opt-in focused-analysis mode. Full analysis remains the default. Focused mode filters policy sections before section-summary LLM calls to a canonical core-section allowlist (`DEFINITIONS`, `EXCLUSIONS`, `CONDITIONS`, `COVERAGE A - DWELLING`, `COVERAGE B - OTHER STRUCTURES`, `COVERAGE C - PERSONAL PROPERTY`, `COVERAGE D - LOSS OF USE`) and skips obvious meta sections.
 - #52 did not change prompts, report schemas/dataclasses, Structured Outputs behavior, model defaults, stage-specific model config, or section-summary concurrency behavior beyond filtering the input section list before `executor.map`.
 - #52 preserves citation/source accordions because `section_text_map` still comes from full raw sections. Raw policy section text is still not persisted. Export context now includes Mode, including Demo Mode plus Focused/Full combinations.
-- Next: start #53 P2-7 Add final Phase 2 benchmark comparison report only. Do not bundle prompt rewrites, report schema changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, deployment/auth/storage work, PDF export work, or unrelated refactors in the #53 PR.
+- `benchmarks/phase2-final.md` is the final Phase 2 comparison report. It preserves `benchmarks/phase2-baseline.md` as historical before-state, records deterministic demo parity, and records current live full/focused measurements for the HO3 TRUE FL fixture.
+- Phase 2 is closed after #53. Do not bundle prompt rewrites, report schema changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, deployment/auth/storage work, PDF export work, token/cost telemetry, quality scoring harnesses, or unrelated refactors into Phase 2 closeout docs.
 
 ## Timeline
 
@@ -43,6 +45,7 @@ Durable project timeline for future Codex and Claude sessions.
 | 2026-04-25 23:58 ET | Section-summary concurrency merged | #50 / PR #62 | Added bounded `ThreadPoolExecutor` concurrency for section-summary LLM calls; `SECTION_SUMMARY_MAX_WORKERS=1` remains the sequential kill-switch. |
 | 2026-04-26 00:25 ET | Redundant live policy PDF reprocessing cleanup merged | #51 / PR #64 | Reuses first-pass raw sections for the in-memory citation source map and strips `section_text_map` before claim persistence to avoid raw policy text persistence. |
 | 2026-04-26 | Focused-analysis mode merged | #52 / PR #66 | Added explicit opt-in focused mode for canonical core policy sections while preserving full analysis as the default and keeping citation/source accordions backed by full raw sections. |
+| 2026-04-26 | Final Phase 2 benchmark comparison added | #53 | Added `benchmarks/phase2-final.md`, kept the historical baseline immutable, and closed Phase 2 with current demo parity plus full/focused live benchmark measurements. |
 
 ## Standing Guardrails
 

--- a/docs/09-session-log.md
+++ b/docs/09-session-log.md
@@ -287,3 +287,35 @@ Track real working sessions so future AI/dev sessions can quickly understand wha
 
 #### Next session starter
 - Start #53 only: final Phase 2 benchmark comparison report, without prompt rewrites, schema/dataclass changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, deployment/auth/storage work, PDF export work, or unrelated refactors.
+
+### 2026-04-26 - Final Phase 2 benchmark comparison
+
+#### Goal
+- Complete #53 as the final Phase 2 issue with a narrow benchmark comparison report.
+
+#### Completed
+- Added a live-mode-only `--focused` option to `scripts/benchmark_phase2_baseline.py`.
+- Added `benchmarks/phase2-final.md`.
+- Preserved `benchmarks/phase2-baseline.md` as the historical before-state report.
+- Recorded deterministic demo parity against the baseline.
+- Recorded current live full and focused measurements for `data/raw_policies/HO3_TRUE_FL_2021.pdf` with `data/raw_denials/HO3_TRUE_FL_2021_denial.txt`.
+- Updated durable docs to mark Phase 2 complete through #53.
+
+#### Decisions
+- Keep the final comparison report separate from the historical baseline report.
+- Close Phase 2 after #53; revisit #18 deployment prep and #20 walkthrough/screenshot recipe separately later.
+
+#### Validation
+- `python -m pytest -q` passed with 85 tests.
+- `python scripts/benchmark_phase2_baseline.py --mode demo --output .tmp/phase2-final-demo.json`
+- `python scripts/benchmark_phase2_baseline.py --mode live --policy-pdf data/raw_policies/HO3_TRUE_FL_2021.pdf --denial-text data/raw_denials/HO3_TRUE_FL_2021_denial.txt --output .tmp/phase2-final-live-full.json`
+- `python scripts/benchmark_phase2_baseline.py --mode live --focused --policy-pdf data/raw_policies/HO3_TRUE_FL_2021.pdf --denial-text data/raw_denials/HO3_TRUE_FL_2021_denial.txt --output .tmp/phase2-final-live-focused.json`
+
+#### Deferred
+- Token/cost telemetry in checked-in benchmark artifacts.
+- A-G quality scoring or evaluation harnesses.
+- Deployment/auth/storage/PDF export work.
+- Public demo work.
+
+#### Next session starter
+- Phase 2 is closed. Pick the next issue explicitly; likely post-Phase-2 candidates are #18 Streamlit deployment prep or #20 walkthrough/screenshot recipe if they are still needed.

--- a/scripts/benchmark_phase2_baseline.py
+++ b/scripts/benchmark_phase2_baseline.py
@@ -198,7 +198,12 @@ def benchmark_demo_bundle() -> Dict[str, Any]:
     }
 
 
-def benchmark_live_pipeline(policy_pdf: Path, denial_text_path: Path) -> Dict[str, Any]:
+def benchmark_live_pipeline(
+    policy_pdf: Path,
+    denial_text_path: Path,
+    *,
+    focused: bool = False,
+) -> Dict[str, Any]:
     from src.demo_api import run_dispute_analysis
     from src.run_baseline_policy_summary import summarize_policy
 
@@ -211,7 +216,13 @@ def benchmark_live_pipeline(policy_pdf: Path, denial_text_path: Path) -> Dict[st
         raise FileNotFoundError(f"Denial text file not found: {denial_text_path}")
 
     with _timed("policy_summary_pipeline", timings):
-        summary_json_path = summarize_policy(policy_pdf)
+        summary_json_path = summarize_policy(policy_pdf, focused=focused)
+
+    summary_payload = _read_json(summary_json_path)
+    summary_sections = summary_payload.get("sections") or []
+    analysis_mode = str(
+        summary_payload.get("analysis_mode") or ("focused" if focused else "full")
+    )
 
     with _timed("load_denial_text", timings):
         denial_text = denial_text_path.read_text(encoding="utf-8", errors="ignore")
@@ -230,6 +241,8 @@ def benchmark_live_pipeline(policy_pdf: Path, denial_text_path: Path) -> Dict[st
         "mode": "live_pipeline",
         "generated_at": datetime.now().astimezone().isoformat(timespec="seconds"),
         "api_calls_made": True,
+        "focused": focused,
+        "analysis_mode": analysis_mode,
         "inputs": {
             "policy_pdf": str(policy_pdf),
             "denial_text": str(denial_text_path),
@@ -237,6 +250,11 @@ def benchmark_live_pipeline(policy_pdf: Path, denial_text_path: Path) -> Dict[st
         "environment": _environment(),
         "total_wall_clock_seconds": total_wall_clock_seconds,
         "stage_timings": timings,
+        "counts": {
+            "policy_summary_sections": (
+                len(summary_sections) if isinstance(summary_sections, list) else None
+            ),
+        },
         "artifacts": {
             "policy_summary_json": str(summary_json_path),
             **(dispute_result.get("artifacts") or {}),
@@ -271,6 +289,11 @@ def parse_args() -> argparse.Namespace:
         help="Denial letter .txt file for --mode live. Requires OPENAI_API_KEY.",
     )
     parser.add_argument(
+        "--focused",
+        action="store_true",
+        help="Use focused-analysis mode for --mode live. Ignored for demo mode.",
+    )
+    parser.add_argument(
         "--output",
         type=Path,
         help="Optional path to write benchmark metrics JSON.",
@@ -286,7 +309,11 @@ def main() -> None:
     else:
         if args.policy_pdf is None or args.denial_text is None:
             raise SystemExit("--mode live requires --policy-pdf and --denial-text")
-        result = benchmark_live_pipeline(args.policy_pdf, args.denial_text)
+        result = benchmark_live_pipeline(
+            args.policy_pdf,
+            args.denial_text,
+            focused=args.focused,
+        )
 
     rendered = json.dumps(result, indent=2, ensure_ascii=False)
     print(rendered)


### PR DESCRIPTION
Closes #53

## Summary
- Adds the final Phase 2 benchmark comparison report.
- Adds focused-mode support to the benchmark harness for current full-vs-focused comparison.
- Records demo parity, current live measurements when available, focused/full section-count comparison, limitations, and final Phase 2 recommendation.
- Marks Phase 2 complete through #53.

## Validation
- python -m pytest -q
- python scripts/benchmark_phase2_baseline.py --mode demo --output .tmp/phase2-final-demo.json
- python scripts/benchmark_phase2_baseline.py --mode live --policy-pdf data/raw_policies/HO3_TRUE_FL_2021.pdf --denial-text data/raw_denials/HO3_TRUE_FL_2021_denial.txt --output .tmp/phase2-final-live-full.json
- python scripts/benchmark_phase2_baseline.py --mode live --focused --policy-pdf data/raw_policies/HO3_TRUE_FL_2021.pdf --denial-text data/raw_denials/HO3_TRUE_FL_2021_denial.txt --output .tmp/phase2-final-live-focused.json
- git diff --check

## Boundaries preserved
- No prompt changes
- No schema/dataclass changes
- No model default changes
- No stage-specific config changes
- No focused-analysis behavior changes
- No concurrency behavior changes
- No citation/source behavior changes
- No deployment/auth/storage/PDF export work