### PR TITLE
[codex] docs: add sales-proof closeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Durable project history lives in:
 - `docs/08-memory.md`
 - `docs/09-session-log.md`
 
+Portfolio / sales-proof positioning lives in:
+
+- `docs/10-sales-proof.md`
+
 ---
 
 ## Repo structure

--- a/docs/01-current-state.md
+++ b/docs/01-current-state.md
@@ -1,8 +1,14 @@
 # Current State
 
-Last updated: 2026-04-26
+Last updated: 2026-04-28
 
 Phase 1 is complete. The app remains a Streamlit research prototype with deterministic Demo Mode, a live API-backed local workflow, README screenshots, and explicit AI-generated / not-legal-advice framing.
+
+## Sales-Proof Positioning
+
+As of 2026-04-28, `docs/10-sales-proof.md` records the portfolio and sales-proof readout. The repo is credible as a private sales demo, website case-study source, and technical proof of AI-assisted insurance document workflow capability.
+
+Do not position it as production-ready, legally accurate, client-proven, or a hosted secure SaaS product. The safest current positioning is: internal research prototype and human-review workflow accelerator for homeowners policy and denial-letter triage.
 
 ## Completed Phase 1A Issues
 

--- a/docs/05-decision-log.md
+++ b/docs/05-decision-log.md
@@ -117,3 +117,20 @@ Use this format for future entries:
 
 ### Revisit trigger
 - Revisit only if a later benchmark issue adds a new measurement scope, telemetry source, or evaluation harness.
+
+## 2026-04-28 ET - Use repo as private sales proof, not public production proof
+
+### Context
+- After Phase 2, the repo has credible demo assets, screenshots, tests, CI, exports, and benchmark docs.
+- It still lacks production deployment, auth, secure hosted storage, broad policy-form support, legal validation, and client outcome evidence.
+
+### Decision
+- Use the repo as private sales proof, website case-study source material, and technical demo evidence.
+- Do not market it as production-ready, legally accurate, client-proven, or a hosted client-facing product.
+
+### Consequence
+- Public and sales copy must preserve research prototype, AI-generated, human-review, demo-safe, and not-legal-advice framing.
+- Public promotion should wait on artifact safety review, walkthrough assets, and clear limitation language.
+
+### Revisit trigger
+- Revisit if the repo gains production deployment, auth/access control, privacy review, quality evaluation, and reviewed client-safe demo materials.

--- a/docs/06-heartbeat.md
+++ b/docs/06-heartbeat.md
@@ -1,6 +1,6 @@
 # Heartbeat
 
-Last updated: 2026-04-26 post-#53 final benchmark report
+Last updated: 2026-04-28 sales-proof docs closeout
 
 ## Current Phase
 - Phase 1 is complete: Phase 1A demo polish, Phase 1B technical closeout, and Phase 1C local/demo trust polish.
@@ -36,11 +36,16 @@ Last updated: 2026-04-26 post-#53 final benchmark report
 - Demo source-map loading hardening is complete via PR #42.
 - #23 human-readable export context and human/AI export grouping are complete via PR #43.
 - The repo remains a research prototype with AI-generated and not-legal-advice framing.
+- `docs/10-sales-proof.md` records the sales-proof and website/case-study positioning.
+- Current portfolio decision: credible private sales demo and case-study material, not public production proof.
+- Safe claims are limited to internal prototype, human-review workflow, homeowners policy and denial-letter triage, A-G dispute summaries, deterministic Demo Mode, Markdown/Word exports, tests, CI, and demo-safe screenshots.
+- Avoid claims of production readiness, legal accuracy, coverage determination, client-proven outcomes, secure hosted SaaS, or broad policy-form support.
 
 ## Next Action
-- Phase 2 is closed after #53. Consider #18 Streamlit deployment prep or #20 walkthrough/video recipe later as separate post-Phase-2 work only when needed.
+- Phase 2 is closed after #53. If public promotion is next, start with artifact safety review and a Demo Mode walkthrough package before hosted deployment.
 
 ## Deferred
+- Public promotion remains deferred until demo assets, tracked generated artifacts, screenshots, and limitation language are reviewed.
 - #18 Streamlit deployment prep — deferred because hosted deployment is not needed yet and adds surface area.
 - #20 walkthrough/video recipe — deferred until after Phase 2 model/API/speed upgrades stabilize.
 
@@ -57,3 +62,4 @@ Last updated: 2026-04-26 post-#53 final benchmark report
 - Section-summary calls use bounded `ThreadPoolExecutor` concurrency; keep `SECTION_SUMMARY_MAX_WORKERS=1` as the sequential kill-switch.
 - The live citation source map reuses first-pass raw sections in memory; `section_text_map` is stripped before claim persistence.
 - Preserve research prototype / AI-generated / not legal advice framing.
+- Do not turn sales copy into production, legal, or client-outcome claims.

--- a/docs/08-memory.md
+++ b/docs/08-memory.md
@@ -26,6 +26,7 @@ Durable project timeline for future Codex and Claude sessions.
 - #52 preserves citation/source accordions because `section_text_map` still comes from full raw sections. Raw policy section text is still not persisted. Export context now includes Mode, including Demo Mode plus Focused/Full combinations.
 - `benchmarks/phase2-final.md` is the final Phase 2 comparison report. It preserves `benchmarks/phase2-baseline.md` as historical before-state, records deterministic demo parity, and records current live full/focused measurements for the HO3 TRUE FL fixture.
 - Phase 2 is closed after #53. Do not bundle prompt rewrites, report schema changes, Structured Outputs changes, model configuration changes, section-summary concurrency changes, retry changes, telemetry semantics changes, deployment/auth/storage work, PDF export work, token/cost telemetry, quality scoring harnesses, or unrelated refactors into Phase 2 closeout docs.
+- `docs/10-sales-proof.md` is the durable sales-proof readout. Use the repo as private sales proof, website case-study source material, and demo evidence only. Do not imply production readiness, legal accuracy, client outcomes, secure hosted SaaS, or broad policy-form support.
 
 ## Timeline
 
@@ -46,6 +47,7 @@ Durable project timeline for future Codex and Claude sessions.
 | 2026-04-26 00:25 ET | Redundant live policy PDF reprocessing cleanup merged | #51 / PR #64 | Reuses first-pass raw sections for the in-memory citation source map and strips `section_text_map` before claim persistence to avoid raw policy text persistence. |
 | 2026-04-26 | Focused-analysis mode merged | #52 / PR #66 | Added explicit opt-in focused mode for canonical core policy sections while preserving full analysis as the default and keeping citation/source accordions backed by full raw sections. |
 | 2026-04-26 | Final Phase 2 benchmark comparison added | #53 | Added `benchmarks/phase2-final.md`, kept the historical baseline immutable, and closed Phase 2 with current demo parity plus full/focused live benchmark measurements. |
+| 2026-04-28 | Sales-proof docs closeout | docs-only | Added `docs/10-sales-proof.md` and recorded that the repo is credible private sales proof, not public production proof. |
 
 ## Standing Guardrails
 
@@ -53,3 +55,4 @@ Durable project timeline for future Codex and Claude sessions.
 - Keep work one issue per PR.
 - Do not commit secrets, real client data, real claim names, claim numbers, or fake client proof.
 - Keep routine logs, archived docs, and screenshots unchanged unless an issue explicitly requires them.
+- Sales and website copy must stay evidence-bound: prototype, demo-safe, human-review, not legal advice.

--- a/docs/09-session-log.md
+++ b/docs/09-session-log.md
@@ -319,3 +319,32 @@ Track real working sessions so future AI/dev sessions can quickly understand wha
 
 #### Next session starter
 - Phase 2 is closed. Pick the next issue explicitly; likely post-Phase-2 candidates are #18 Streamlit deployment prep or #20 walkthrough/screenshot recipe if they are still needed.
+
+### 2026-04-28 - Sales-proof docs closeout
+
+#### Goal
+- Capture the final sales-proof, website, demo, and client-facing evidence readout before ending the session.
+
+#### Completed
+- Added `docs/10-sales-proof.md`.
+- Linked the sales-proof doc from `README.md`.
+- Updated current state, heartbeat, memory, and decision log with the private-sales-proof positioning.
+- Preserved the current framing: research prototype, AI-generated, human-review, demo-safe, and not legal advice.
+
+#### Decisions
+- Use the repo as credible private sales proof and website/case-study source material.
+- Do not market it as production-ready, legally accurate, client-proven, or a hosted secure SaaS product.
+- See `docs/05-decision-log.md` for the 2026-04-28 sales-proof decision.
+
+#### Validation
+- `git diff --check` passed.
+- Full pytest not run because this was docs-only.
+
+#### Deferred
+- Public promotion package.
+- Artifact safety review for tracked generated outputs.
+- Walkthrough video and citation/source screenshot refresh.
+- Hosted deployment, auth, storage, and production readiness work.
+
+#### Next session starter
+- If promotion is next, start with artifact safety review and a Demo Mode walkthrough package using `docs/10-sales-proof.md` as the positioning source.

--- a/docs/10-sales-proof.md
+++ b/docs/10-sales-proof.md
@@ -1,0 +1,188 @@
+# Sales Proof Review
+
+Last updated: 2026-04-28
+
+This document records what this repository can safely support as sales proof, website content, demo material, or client-facing evidence. It is intentionally evidence-bound: do not use it to imply production readiness, legal accuracy, client outcomes, or broad policy-form coverage.
+
+## Sales-Proof Summary
+
+This repo is credible as a private sales demo, technical case study, and portfolio proof for AI-assisted insurance document workflows.
+
+It should be positioned as:
+
+- Internal research prototype.
+- Human-review workflow accelerator.
+- Demo-safe claim triage example.
+- Technical proof that IT Pro Direct can build document intake, LLM analysis, source-linked review, and export workflows.
+
+It should not be positioned as:
+
+- Production SaaS.
+- Legal advice.
+- Coverage determination.
+- Validated claim outcome engine.
+- Secure hosted client portal.
+
+## What This Repo Proves
+
+The repo proves the team can build a working vertical slice for insurance claim document review:
+
+- Streamlit claim intake and results UI.
+- Homeowners policy PDF and denial-letter workflow.
+- A-G dispute report structure for first-pass human review.
+- OpenAI Responses API integration through a single wrapper.
+- Strict Structured Outputs for final dispute reports.
+- Bounded concurrent section-summary calls.
+- Focused-analysis mode for core policy sections.
+- Demo Mode with deterministic checked-in assets and no API calls.
+- Source/citation accordions backed by demo-safe source excerpts.
+- Markdown and Word exports with human-readable context.
+- Local SQLite claim history.
+- Pytest coverage and GitHub Actions CI.
+- Benchmark docs for demo parity and live full-vs-focused comparison.
+
+## Client Problem Mapped
+
+The strongest client problem is slow first-pass claim file review.
+
+Public adjusters, coverage attorneys, and claim-review professionals need to quickly understand:
+
+- What the policy may support.
+- What exclusions, limitations, and conditions may matter.
+- What the carrier said in the denial.
+- What dispute angles deserve human review.
+- What facts or documents are still missing.
+
+This repo demonstrates a workflow that organizes that review into a structured brief.
+
+## Best-Fit Buyer Or User
+
+Best-fit users:
+
+- Public adjusting firms.
+- Coverage attorneys.
+- Property claim consultants.
+- CAT claim review teams.
+- Insurance-document operations teams.
+
+Best-fit buyer:
+
+- A claims leader, firm owner, or operations lead who wants a private AI workflow to speed up document-heavy triage while keeping humans responsible for final judgment.
+
+## Suggested Offer
+
+Offer name:
+
+**AI Claim Triage Prototype Sprint**
+
+Offer shape:
+
+- One document-heavy claim workflow.
+- One policy form or claim type first.
+- Private/local or demo-safe deployment first.
+- Human-reviewed outputs only.
+- Exportable review brief.
+- Clear privacy, safety, and not-legal-advice framing.
+
+A hosted multi-user claim-review platform remains aspirational. This repo does not prove auth, billing, secure multi-tenant storage, client onboarding, or production compliance.
+
+## Website Section Draft
+
+### Headline
+
+AI-assisted claim review, built for faster first-pass triage.
+
+### Proof Bullets
+
+- Built a working prototype that turns homeowners policy language and denial-letter content into structured A-G dispute summaries.
+- Added deterministic Demo Mode with uploads and API calls disabled for safe walkthroughs.
+- Implemented source-linked review views, Markdown/Word exports, automated tests, CI, and benchmark reporting.
+
+### Case-Study Paragraph
+
+We built an internal Policy Dispute AI prototype to explore how AI can help claim professionals organize homeowners policy language and denial letters into a faster review brief. The app extracts policy text, groups it into policy sections, summarizes relevant coverage concepts, analyzes denial reasons, and presents a structured A-G dispute report for human review.
+
+### Technical Credibility Paragraph
+
+The prototype uses a Python backend, Streamlit frontend, OpenAI Responses API integration, Structured Outputs for final reports, bounded concurrent section summaries, focused-analysis mode, citation/source accordions, local SQLite claim history, Markdown and Word exports, deterministic offline demo assets, pytest coverage, and GitHub Actions CI. It is explicitly framed as a research prototype, not legal advice or a production legal product.
+
+## Demo Walkthrough
+
+### 90-Second Version
+
+1. Open the app overview and point to the research prototype, not-legal-advice, and AI-generated framing.
+2. Turn on Demo Mode or show hosted public demo safety mode.
+3. Jump to Results.
+4. Show the plain-language dispute overview and key takeaways.
+5. Open the A-G dispute structure.
+6. Open one source/citation accordion.
+7. Show Word and Markdown export buttons.
+8. Close by saying this is a human-review accelerator, not a coverage decision engine.
+
+### 5-Minute Version
+
+1. Explain the client problem: long policies and denial letters slow down first-pass review.
+2. Show New Claim intake: claim nickname, state, policy PDF, denial PDF.
+3. Explain Demo Mode: deterministic, no uploads, no API calls.
+4. Show Results overview and review context.
+5. Walk through A-G sections: overview, coverage highlights, exclusions, denial reasons, dispute angles, missing information, confidence.
+6. Open a source accordion to show citation-linked policy context.
+7. Show Word and Markdown exports.
+8. Mention technical evidence: tests, CI, benchmark report, focused-analysis mode.
+9. End with limitations: prototype, not legal advice, source documents must be reviewed.
+
+## Screenshot And Video Checklist
+
+Existing screenshots:
+
+- `docs/screenshots/01-app-overview-framing.png`
+- `docs/screenshots/02-new-claim-upload-form.png`
+- `docs/screenshots/03-demo-safety-state.png`
+- `docs/screenshots/04-results-overview.png`
+- `docs/screenshots/05-results-actions-downloads.png`
+
+Needed before public promotion:
+
+- Fresh screenshots after any copy or UI change.
+- One 90-second narrated demo using Demo Mode only.
+- One 5-minute technical walkthrough.
+- Screenshot with a source/citation accordion open.
+- Screenshot of the A-G tabs.
+- Screenshot of export context.
+- Final check that screenshots show no secrets, real client names, claim numbers, or real client data.
+
+## Claims We Can Safely Make
+
+- Internal research prototype.
+- AI-generated, human-review workflow.
+- Designed for homeowners policy and denial-letter triage.
+- Produces structured A-G dispute summaries.
+- Includes deterministic offline demo mode.
+- Supports Markdown and Word exports.
+- Includes automated tests and GitHub Actions CI.
+- Uses demo-safe artifacts for public screenshots.
+- Not legal advice and not a coverage decision.
+
+## Claims To Avoid
+
+- Production-ready.
+- Legally accurate.
+- Determines coverage.
+- Wins disputes.
+- Replaces attorneys or public adjusters.
+- Works for all policy forms.
+- Secure SaaS platform.
+- Client-proven.
+- Handles real client data safely in hosted mode.
+- Validated against real claim outcomes.
+
+## Next Work Before Public Promotion
+
+1. Confirm or remove tracked generated `data/processed` artifacts.
+2. Make every public artifact explicitly demo-safe and non-client.
+3. Create a polished walkthrough video using Demo Mode only.
+4. Add a compact public case-study page with careful disclaimers.
+5. Add a citation/source screenshot to the README or website.
+6. Add a lightweight evaluation note documenting what is tested and what is not.
+7. Keep hosted/demo mode locked with uploads and API calls disabled.
+8. Do not promote live client use until privacy, deployment, auth, and quality-review gaps are addressed.


### PR DESCRIPTION
## Summary
- add docs/10-sales-proof.md with evidence-bound sales, demo, website, and client-facing positioning
- link the sales-proof doc from the README
- update durable docs for current state, heartbeat, memory, decision log, and session closeout

## Validation
- git diff --check
- git diff --cached --check
- CI pytest passed on GitHub

Docs-only change; full local pytest was not run.